### PR TITLE
feat: add `ignored-annotations` option to `avoid-returning-widgets` rule to allow using libraries like "functional_widget"

### DIFF
--- a/doc/rules/avoid-returning-widgets.md
+++ b/doc/rules/avoid-returning-widgets.md
@@ -33,9 +33,11 @@ dart_code_metrics:
     - avoid-returning-widgets:
         ignored-names:
           - testFunction
+        ignored-annotations:
+          - FunctionalWidget
 ```
 
-will ignore all functions named `testFunction`.
+will ignore all functions named `testFunction` and all functions having `FunctionalWidget` annotation.
 
 ### Example
 

--- a/doc/rules/avoid-returning-widgets.md
+++ b/doc/rules/avoid-returning-widgets.md
@@ -8,7 +8,10 @@ avoid-returning-widgets
 
 ## Description
 
-Warns when a method or function returns a Widget or subclass of a Widget (**Note** `build` method will not trigger the rule).
+Warns when a method or function returns a Widget or subclass of a Widget. The following patterns will not trigger the rule:
+
+- Widget `build` method overrides.
+- Functions with [functional_widget](https://pub.dev/packages/functional_widget) package annotations.
 
 Extracting widgets to a method is considered as a Flutter anti-pattern, because when Flutter rebuilds widget tree, it calls the function all the time, making more processor time for the operations.
 
@@ -21,7 +24,7 @@ Additional resources:
 * <https://www.reddit.com/r/FlutterDev/comments/avhvco/extracting_widgets_to_a_function_is_not_an/>
 * <https://medium.com/flutter-community/splitting-widgets-to-methods-is-a-performance-antipattern-16aa3fb4026c>
 
-Use `ignored-names` configuration, if you want to ignore a function or method name. For example:
+Use `ignored-names` configuration, if you want to ignore a function or method name. Use `ignored-annotations` configuration, if you want to override default ignored annotation list. For example:
 
 ### Config example
 
@@ -34,10 +37,10 @@ dart_code_metrics:
         ignored-names:
           - testFunction
         ignored-annotations:
-          - FunctionalWidget
+          - allowedAnnotation
 ```
 
-will ignore all functions named `testFunction` and all functions having `FunctionalWidget` annotation.
+will ignore all functions named `testFunction` and all functions having `allowedAnnotation` annotation.
 
 ### Example
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/avoid_returning_widgets.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/avoid_returning_widgets.dart
@@ -20,9 +20,11 @@ class AvoidReturningWidgetsRule extends Rule {
   static const _warningMessage = 'Avoid returning widgets from a function.';
 
   final Iterable<String> _ignoredNames;
+  final Iterable<String> _ignoredAnnotations;
 
   AvoidReturningWidgetsRule([Map<String, Object> config = const {}])
       : _ignoredNames = _ConfigParser.getIgnoredNames(config),
+        _ignoredAnnotations = _ConfigParser.getIgnoredAnnotations(config),
         super(
           id: ruleId,
           documentation: const RuleDocumentation(
@@ -36,7 +38,7 @@ class AvoidReturningWidgetsRule extends Rule {
 
   @override
   Iterable<Issue> check(InternalResolvedUnitResult source) {
-    final _visitor = _Visitor(_ignoredNames);
+    final _visitor = _Visitor(_ignoredNames, _ignoredAnnotations);
 
     source.unit.visitChildren(_visitor);
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/config_parser.dart
@@ -2,10 +2,19 @@ part of 'avoid_returning_widgets.dart';
 
 class _ConfigParser {
   static const _ignoredNamesConfig = 'ignored-names';
+  static const _ignoredAnnotationsConfig = 'ignored-annotations';
 
   static Iterable<String> getIgnoredNames(Map<String, Object> config) =>
-      config.containsKey(_ignoredNamesConfig) &&
-              config[_ignoredNamesConfig] is Iterable
-          ? List<String>.from(config[_ignoredNamesConfig] as Iterable)
+      _getIterable(config, _ignoredNamesConfig);
+
+  static Iterable<String> getIgnoredAnnotations(Map<String, Object> config) =>
+      _getIterable(config, _ignoredAnnotationsConfig);
+
+  static Iterable<String> _getIterable(
+    Map<String, Object> config,
+    String name,
+  ) =>
+      config.containsKey(name) && config[name] is Iterable
+          ? List<String>.from(config[name] as Iterable)
           : <String>[];
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/config_parser.dart
@@ -4,17 +4,24 @@ class _ConfigParser {
   static const _ignoredNamesConfig = 'ignored-names';
   static const _ignoredAnnotationsConfig = 'ignored-annotations';
 
+  static const _defaultIgnoredAnnotations = [
+    'FunctionalWidget',
+    'swidget',
+    'hwidget',
+  ];
+
   static Iterable<String> getIgnoredNames(Map<String, Object> config) =>
-      _getIterable(config, _ignoredNamesConfig);
+      _getIterable(config, _ignoredNamesConfig) ?? [];
 
   static Iterable<String> getIgnoredAnnotations(Map<String, Object> config) =>
-      _getIterable(config, _ignoredAnnotationsConfig);
+      _getIterable(config, _ignoredAnnotationsConfig) ??
+      _defaultIgnoredAnnotations;
 
-  static Iterable<String> _getIterable(
+  static Iterable<String>? _getIterable(
     Map<String, Object> config,
     String name,
   ) =>
-      config.containsKey(name) && config[name] is Iterable
+      config[name] is Iterable
           ? List<String>.from(config[name] as Iterable)
-          : <String>[];
+          : null;
 }

--- a/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/avoid_returning_widgets_test.dart
+++ b/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/avoid_returning_widgets_test.dart
@@ -28,10 +28,10 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startOffsets: [88, 175, 289, 358, 485, 614, 749, 822, 895],
-        startLines: [6, 11, 20, 25, 30, 35, 41, 46, 50],
-        startColumns: [3, 3, 3, 3, 3, 3, 1, 1, 1],
-        endOffsets: [127, 231, 344, 414, 542, 677, 784, 885, 954],
+        startOffsets: [88, 175, 289, 358, 485, 614, 749, 1012],
+        startLines: [6, 11, 20, 25, 30, 35, 41, 55],
+        startColumns: [3, 3, 3, 3, 3, 3, 1, 1],
+        endOffsets: [127, 231, 344, 414, 542, 677, 784, 1087],
         locationTexts: [
           'Widget get widgetGetter => Container();',
           'Widget _getMyShinyWidget() {\n'
@@ -44,13 +44,10 @@ void main() {
           'List<Widget> _getWidgetsList() => [Container()].toList();',
           'Future<Widget> _getWidgetFuture() => Future.value(Container());',
           'Widget _getWidget() => Container();',
-          '@FunctionalWidget\n'
-              'Widget _getFunctionalWidget() => Container();',
-          '@swidget\n'
-              'Widget _getOtherFunctionalWidget() => Container();',
+          '@ignoredAnnotation\n'
+              'Widget _getWidgetWithIgnoredAnnotation() => Container();'
         ],
         messages: [
-          'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',
@@ -71,8 +68,7 @@ void main() {
           '_getWidget',
         ],
         'ignored-annotations': [
-          'FunctionalWidget',
-          'swidget',
+          'ignoredAnnotation',
         ]
       };
 
@@ -80,10 +76,10 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startOffsets: [88, 175, 289, 358, 485],
-        startLines: [6, 11, 20, 25, 30],
-        startColumns: [3, 3, 3, 3, 3],
-        endOffsets: [127, 231, 344, 414, 542],
+        startOffsets: [88, 175, 289, 358, 485, 814, 879, 944],
+        startLines: [6, 11, 20, 25, 30, 45, 48, 51],
+        startColumns: [3, 3, 3, 3, 3, 1, 1, 1],
+        endOffsets: [127, 231, 344, 414, 542, 877, 942, 1002],
         locationTexts: [
           'Widget get widgetGetter => Container();',
           'Widget _getMyShinyWidget() {\n'
@@ -94,8 +90,17 @@ void main() {
               '  }',
           'Iterable<Widget> _getWidgetsIterable() => [Container()];',
           'List<Widget> _getWidgetsList() => [Container()].toList();',
+          '@FunctionalWidget\n'
+              'Widget _getFunctionalWidget() => Container();',
+          '@swidget\n'
+              'Widget _getStatelessFunctionalWidget() => Container();',
+          '@hwidget\n'
+              'Widget _getHookFunctionalWidget() => Container();'
         ],
         messages: [
+          'Avoid returning widgets from a function.',
+          'Avoid returning widgets from a function.',
+          'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',

--- a/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/avoid_returning_widgets_test.dart
+++ b/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/avoid_returning_widgets_test.dart
@@ -69,7 +69,7 @@ void main() {
         ],
         'ignored-annotations': [
           'ignoredAnnotation',
-        ]
+        ],
       };
 
       final issues = AvoidReturningWidgetsRule(config).check(unit);

--- a/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/avoid_returning_widgets_test.dart
+++ b/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/avoid_returning_widgets_test.dart
@@ -28,10 +28,10 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startOffsets: [88, 175, 289, 358, 485, 614, 749],
-        startLines: [6, 11, 20, 25, 30, 35, 41],
-        startColumns: [3, 3, 3, 3, 3, 3, 1],
-        endOffsets: [127, 231, 344, 414, 542, 677, 784],
+        startOffsets: [88, 175, 289, 358, 485, 614, 749, 822, 895],
+        startLines: [6, 11, 20, 25, 30, 35, 41, 46, 50],
+        startColumns: [3, 3, 3, 3, 3, 3, 1, 1, 1],
+        endOffsets: [127, 231, 344, 414, 542, 677, 784, 885, 954],
         locationTexts: [
           'Widget get widgetGetter => Container();',
           'Widget _getMyShinyWidget() {\n'
@@ -44,8 +44,14 @@ void main() {
           'List<Widget> _getWidgetsList() => [Container()].toList();',
           'Future<Widget> _getWidgetFuture() => Future.value(Container());',
           'Widget _getWidget() => Container();',
+          '@FunctionalWidget\n'
+              'Widget _getFunctionalWidget() => Container();',
+          '@swidget\n'
+              'Widget _getOtherFunctionalWidget() => Container();',
         ],
         messages: [
+          'Avoid returning widgets from a function.',
+          'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',
           'Avoid returning widgets from a function.',
@@ -64,6 +70,10 @@ void main() {
           '_getWidgetFuture',
           '_getWidget',
         ],
+        'ignored-annotations': [
+          'FunctionalWidget',
+          'swidget',
+        ]
       };
 
       final issues = AvoidReturningWidgetsRule(config).check(unit);

--- a/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/examples/example.dart
+++ b/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/examples/example.dart
@@ -42,13 +42,18 @@ Widget _getWidget() => Container();
 
 String _getString() => '';
 
-// LINT
 @FunctionalWidget
 Widget _getFunctionalWidget() => Container();
 
-// LINT
 @swidget
-Widget _getOtherFunctionalWidget() => Container();
+Widget _getStatelessFunctionalWidget() => Container();
+
+@hwidget
+Widget _getHookFunctionalWidget() => Container();
+
+// LINT
+@ignoredAnnotation
+Widget _getWidgetWithIgnoredAnnotation() => Container();
 
 class Widget {}
 
@@ -59,3 +64,8 @@ class FunctionalWidget {
 }
 
 const swidget = FunctionalWidget();
+const hwidget = FunctionalWidget();
+
+class IgnoredAnnotation {
+  const IgnoredAnnotation();
+}

--- a/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/examples/example.dart
+++ b/test/analyzers/lint_analyzer/rules/rules_list/avoid_returning_widgets/examples/example.dart
@@ -42,6 +42,20 @@ Widget _getWidget() => Container();
 
 String _getString() => '';
 
+// LINT
+@FunctionalWidget
+Widget _getFunctionalWidget() => Container();
+
+// LINT
+@swidget
+Widget _getOtherFunctionalWidget() => Container();
+
 class Widget {}
 
 class Container extends Widget {}
+
+class FunctionalWidget {
+  const FunctionalWidget();
+}
+
+const swidget = FunctionalWidget();


### PR DESCRIPTION
We use [functional_widget](https://pub.dev/packages/functional_widget) library in our Flutter projects to avoid boilerplate code when creating simple stateless flutter widgets. 

In such case there is nothing bad in returning widgets from function because stateless widget class is being generated. So I suggest to add `ignored-annotations` option to `avoid-returning-widgets` rule to allow to use `functional_widget` library without having to always ignore rule violation.