### PR TITLE
chore: enforce LF line endings when working in Visual Studio Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "files.eol": "\n",
     "cSpell.words": [
         "Backport",
         "McCabe's",


### PR DESCRIPTION
An improvement for already closed issue #329.