### PR TITLE
chore: simplify configuration parsers

### DIFF
--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/component_annotation_arguments_ordering/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/component_annotation_arguments_ordering/config_parser.dart
@@ -4,10 +4,9 @@ class _ConfigParser {
   static const _orderConfig = 'order';
 
   static List<_ArgumentGroup> parseOrder(Map<String, Object> config) {
-    final order =
-        config.containsKey(_orderConfig) && config[_orderConfig] is Iterable
-            ? List<String>.from(config[_orderConfig] as Iterable)
-            : <String>[];
+    final order = config[_orderConfig] is Iterable
+        ? List<String>.from(config[_orderConfig] as Iterable)
+        : <String>[];
 
     return order.isEmpty
         ? _ArgumentGroup._groupsOrder

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/member_ordering/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/member_ordering/config_parser.dart
@@ -4,10 +4,9 @@ class _ConfigParser {
   static const _orderConfig = 'order';
 
   static List<_MembersGroup> parseOrder(Map<String, Object> config) {
-    final order =
-        config.containsKey(_orderConfig) && config[_orderConfig] is Iterable
-            ? List<String>.from(config[_orderConfig] as Iterable)
-            : <String>[];
+    final order = config[_orderConfig] is Iterable
+        ? List<String>.from(config[_orderConfig] as Iterable)
+        : <String>[];
 
     return order.isEmpty
         ? _MembersGroup._groupsOrder

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/member_ordering_extended/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/member_ordering_extended/config_parser.dart
@@ -20,7 +20,7 @@ class _ConfigParser {
   );
 
   static List<_MemberGroup> parseOrder(Map<String, Object> config) {
-    final order = config.containsKey('order') && config['order'] is Iterable
+    final order = config['order'] is Iterable
         ? List<String>.from(config['order'] as Iterable)
         : _defaultOrderList;
 


### PR DESCRIPTION
Removed code seems to be redundant, see https://github.com/dart-code-checker/dart-code-metrics/pull/330#discussion_r634173790