### PR TITLE
[DO_NOT_MERGE] research: CLI performance issue profiling

### DIFF
--- a/lib/src/analyzers/lint_analyzer/lint_analyzer.dart
+++ b/lib/src/analyzers/lint_analyzer/lint_analyzer.dart
@@ -95,24 +95,37 @@ class LintAnalyzer {
 
     final analyzerResult = <FileReport>[];
 
+    var totalContextForMs = 0;
+    var totalGetResolvedUnitMs = 0;
+    var totalRunAnalysisforFileMs = 0;
+    DateTime startTime;
     for (final filePath in filePaths) {
       final normalized = normalize(absolute(filePath));
 
+      startTime = DateTime.now();
       final analysisContext = collection.contextFor(normalized);
+      totalContextForMs += DateTime.now().difference(startTime).inMilliseconds;
+
+      startTime = DateTime.now();
       final unit =
           // ignore: deprecated_member_use
           await analysisContext.currentSession.getResolvedUnit(normalized);
+      totalGetResolvedUnitMs += DateTime.now().difference(startTime).inMilliseconds;
+
+      startTime = DateTime.now();
       final result = _runAnalysisForFile(
         unit,
         config,
         rootFolder,
         filePath: filePath,
       );
+      totalRunAnalysisforFileMs += DateTime.now().difference(startTime).inMilliseconds;
 
       if (result != null) {
         analyzerResult.add(result);
       }
     }
+    print('contextForMs: $totalContextForMs, getResolvedUnitMs: $totalGetResolvedUnitMs, runAnalysisforFileMs: $totalRunAnalysisforFileMs');
 
     return analyzerResult;
   }


### PR DESCRIPTION
I started integrating the project into our codebase and found that CLI runs extremely slow compared to `dart analyze` command. 

`dart analyze` command takes about 3-5 seconds on our codebase, `dart_code_metrics` CLI runs about two minutes.

I am not sure if this is some environment configuration or maybe Windows issue. On my machine results of this simple profiling code are:

`contextForMs: 76, getResolvedUnitMs: 115290, runAnalysisforFileMs: 128`.

So `analysisContext.currentSession.getResolvedUnit` method call seems to be **extremely** slow (in another performance test I made I see that it might even take several seconds to complete for just one file). At the moment I do not know how to speed up this...

@incendial, @dkrutskikh - can you please check (when you have time) if this issue can be reproduced on your machines and if we actually have serious performance issue here?
