### PR TITLE
fix: plugin quick fix action performs on wrong file for file with `pa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix analyzer plugin quick fix action performs on wrong file for file with `part of`.
+
 ## 4.0.0-dev.3
 
 * Fix plugin integration null reference.

--- a/lib/src/analyzer_plugin/analyzer_plugin_utils.dart
+++ b/lib/src/analyzer_plugin/analyzer_plugin_utils.dart
@@ -12,48 +12,51 @@ import '../utils/path_utils.dart';
 plugin.AnalysisErrorFixes codeIssueToAnalysisErrorFixes(
   Issue issue,
   ResolvedUnitResult? unitResult,
-) =>
-    plugin.AnalysisErrorFixes(
-      plugin.AnalysisError(
-        _severityMapping[issue.severity]!,
-        plugin.AnalysisErrorType.LINT,
-        plugin.Location(
-          uriToPath(issue.location.sourceUrl) ?? '',
-          issue.location.start.offset,
-          issue.location.length,
-          issue.location.start.line,
-          issue.location.start.column,
-          issue.location.end.line,
-          issue.location.end.column,
-        ),
-        issue.message,
-        issue.ruleId,
-        correction:
-            '${issue.verboseMessage ?? ''} ${issue.suggestion?.replacement ?? ''}'
-                .trim(),
-        url: issue.documentation.toString(),
-        hasFix: issue.suggestion != null,
+) {
+  final fileWithIssue = uriToPath(issue.location.sourceUrl) ?? '';
+
+  return plugin.AnalysisErrorFixes(
+    plugin.AnalysisError(
+      _severityMapping[issue.severity]!,
+      plugin.AnalysisErrorType.LINT,
+      plugin.Location(
+        fileWithIssue,
+        issue.location.start.offset,
+        issue.location.length,
+        issue.location.start.line,
+        issue.location.start.column,
+        issue.location.end.line,
+        issue.location.end.column,
       ),
-      fixes: [
-        if (issue.suggestion != null && unitResult != null)
-          plugin.PrioritizedSourceChange(
-            1,
-            plugin.SourceChange(issue.suggestion!.comment, edits: [
-              plugin.SourceFileEdit(
-                unitResult.libraryElement.source.fullName,
-                unitResult.libraryElement.source.modificationStamp,
-                edits: [
-                  plugin.SourceEdit(
-                    issue.location.start.offset,
-                    issue.location.length,
-                    issue.suggestion!.replacement,
-                  ),
-                ],
-              ),
-            ]),
-          ),
-      ],
-    );
+      issue.message,
+      issue.ruleId,
+      correction:
+          '${issue.verboseMessage ?? ''} ${issue.suggestion?.replacement ?? ''}'
+              .trim(),
+      url: issue.documentation.toString(),
+      hasFix: issue.suggestion != null,
+    ),
+    fixes: [
+      if (issue.suggestion != null && unitResult != null)
+        plugin.PrioritizedSourceChange(
+          1,
+          plugin.SourceChange(issue.suggestion!.comment, edits: [
+            plugin.SourceFileEdit(
+              fileWithIssue,
+              unitResult.libraryElement.source.modificationStamp,
+              edits: [
+                plugin.SourceEdit(
+                  issue.location.start.offset,
+                  issue.location.length,
+                  issue.suggestion!.replacement,
+                ),
+              ],
+            ),
+          ]),
+        ),
+    ],
+  );
+}
 
 plugin.AnalysisErrorFixes designIssueToAnalysisErrorFixes(Issue issue) =>
     plugin.AnalysisErrorFixes(plugin.AnalysisError(


### PR DESCRIPTION
…rt of`

<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)


### Is there anything you'd like reviewers to focus on?
