### PR TITLE
feat: don't trigger prefer-extracting-callbacks on empty function blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Don't trigger prefer-extracting-callbacks on empty function blocks.
 * Improve unused files check, add support for `vm:entry-point` annotation.
 
 ## 4.3.1

--- a/doc/rules/prefer-extracting-callbacks.md
+++ b/doc/rules/prefer-extracting-callbacks.md
@@ -10,7 +10,9 @@ prefer-extracting-callbacks
 
 Warns about inline callbacks in a widget tree and suggests to extract them to widget methods in order to make a `build` method more readable. In addition extracting can help test those methods separately as well.
 
-**NOTE** the rule will not trigger on arrow functions like `onPressed: () => _handler(...)` in order to cover cases when a callback needs a variable from the outside.
+**NOTE** the rule will not trigger on: 
+ - arrow functions like `onPressed: () => _handler(...)` in order to cover cases when a callback needs a variable from the outside;
+ - empty blocks.
 
 Use `ignored-named-arguments` configuration, if you want to ignore specific named parameters (`builder` argument is ignored by default).
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
@@ -40,10 +40,19 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
 
       if (_isNotIgnored(argument) &&
           expression is FunctionExpression &&
-          expression.body is BlockFunctionBody) {
+          _hasNotEmptyBlockBody(expression)) {
         _expressions.add(argument);
       }
     }
+  }
+
+  bool _hasNotEmptyBlockBody(FunctionExpression expression) {
+    final body = expression.body;
+    if (body is! BlockFunctionBody) {
+      return false;
+    }
+
+    return body.block.statements.isNotEmpty;
   }
 
   bool _isNotIgnored(Expression argument) =>

--- a/test/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/examples/example.dart
+++ b/test/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/examples/example.dart
@@ -65,6 +65,23 @@ class MyAnotherWidget extends StatelessWidget {
   void _someMethod() {}
 }
 
+class MyWidgetWithEmptyCallbacks extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final widget = AnotherButton(
+      () {},
+      Container(),
+    );
+
+    return TextButton(
+      onPressed: () {
+        // Just a comment here.
+      },
+      child: Container(),
+    );
+  }
+}
+
 class Widget {}
 
 class StatelessWidget extends Widget {}


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[X] Changes an existing rule `prefer-extracting-callbacks` (#458)
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

`prefer-extracting-callbacks` rule doesn't trigger on the empty block functions.

### Is there anything you'd like reviewers to focus on?

–