### PR TITLE
feat: ignore Flutter builder functions in "prefer-extracting-callbacks" rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * feat: Add static code diagnostic `prefer-const-border-radius`.
 * Improve static code diagnostic `prefer-extracting-callbacks`, don't trigger on empty function blocks.
 * Improve unused files check, add support for `vm:entry-point` annotation.
+* feat: ignore Flutter builder functions in `prefer-extracting-callbacks` rule.
 
 ## 4.3.3
 

--- a/doc/rules/prefer-extracting-callbacks.md
+++ b/doc/rules/prefer-extracting-callbacks.md
@@ -13,8 +13,9 @@ Warns about inline callbacks in a widget tree and suggests to extract them to wi
 **NOTE** the rule will not trigger on: 
  - arrow functions like `onPressed: () => _handler(...)` in order to cover cases when a callback needs a variable from the outside;
  - empty blocks.
+ - Flutter specific: arguments with functions having return type named `Widget` and with first parameter of type named `BuildContext`. "Builder" functions is a common pattern in Flutter, for example, [IndexedWidgetBuilder typedef](https://api.flutter.dev/flutter/widgets/IndexedWidgetBuilder.html) is used in [ListView.builder](https://api.flutter.dev/flutter/widgets/ListView/ListView.builder.html).
 
-Use `ignored-named-arguments` configuration, if you want to ignore specific named parameters (`builder` argument is ignored by default).
+Use `ignored-named-arguments` configuration, if you want to ignore specific named parameters.
 
 ### Config example
 

--- a/doc/rules/prefer-extracting-callbacks.md
+++ b/doc/rules/prefer-extracting-callbacks.md
@@ -13,7 +13,7 @@ Warns about inline callbacks in a widget tree and suggests to extract them to wi
 **NOTE** the rule will not trigger on: 
  - arrow functions like `onPressed: () => _handler(...)` in order to cover cases when a callback needs a variable from the outside;
  - empty blocks.
- - Flutter specific: arguments with functions having return type named `Widget` and with first parameter of type named `BuildContext`. "Builder" functions is a common pattern in Flutter, for example, [IndexedWidgetBuilder typedef](https://api.flutter.dev/flutter/widgets/IndexedWidgetBuilder.html) is used in [ListView.builder](https://api.flutter.dev/flutter/widgets/ListView/ListView.builder.html).
+ - Flutter specific: arguments with functions returning `Widget` type (or its subclass) and with first parameter of type `BuildContext`. "Builder" functions is a common pattern in Flutter, for example, [IndexedWidgetBuilder typedef](https://api.flutter.dev/flutter/widgets/IndexedWidgetBuilder.html) is used in [ListView.builder](https://api.flutter.dev/flutter/widgets/ListView/ListView.builder.html).
 
 Use `ignored-named-arguments` configuration, if you want to ignore specific named parameters.
 

--- a/lib/src/analyzers/lint_analyzer/rules/flutter_rule_utils.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/flutter_rule_utils.dart
@@ -8,7 +8,7 @@ bool hasWidgetType(DartType type) =>
     _isFuture(type);
 
 bool isWidgetOrSubclass(DartType? type) =>
-    _isWidget(type) || _isSubclassOfWidget(type);
+    isWidget(type) || _isSubclassOfWidget(type);
 
 bool isWidgetStateOrSubclass(DartType? type) =>
     _isWidgetState(type) || _isSubclassOfWidgetState(type);
@@ -19,11 +19,14 @@ bool isSubclassOfListenable(DartType? type) =>
 bool isPaddingWidget(DartType? type) =>
     type?.getDisplayString(withNullability: false) == 'Padding';
 
-bool _isWidget(DartType? type) =>
+bool isWidget(DartType? type) =>
     type?.getDisplayString(withNullability: false) == 'Widget';
 
+bool isBuildContext(DartType? type) =>
+    type?.getDisplayString(withNullability: false) == 'BuildContext';
+
 bool _isSubclassOfWidget(DartType? type) =>
-    type is InterfaceType && type.allSupertypes.any(_isWidget);
+    type is InterfaceType && type.allSupertypes.any(isWidget);
 
 bool _isWidgetState(DartType? type) => type?.element?.displayName == 'State';
 

--- a/lib/src/analyzers/lint_analyzer/rules/flutter_rule_utils.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/flutter_rule_utils.dart
@@ -8,7 +8,7 @@ bool hasWidgetType(DartType type) =>
     _isFuture(type);
 
 bool isWidgetOrSubclass(DartType? type) =>
-    isWidget(type) || _isSubclassOfWidget(type);
+    _isWidget(type) || _isSubclassOfWidget(type);
 
 bool isWidgetStateOrSubclass(DartType? type) =>
     _isWidgetState(type) || _isSubclassOfWidgetState(type);
@@ -19,14 +19,14 @@ bool isSubclassOfListenable(DartType? type) =>
 bool isPaddingWidget(DartType? type) =>
     type?.getDisplayString(withNullability: false) == 'Padding';
 
-bool isWidget(DartType? type) =>
+bool _isWidget(DartType? type) =>
     type?.getDisplayString(withNullability: false) == 'Widget';
 
 bool isBuildContext(DartType? type) =>
     type?.getDisplayString(withNullability: false) == 'BuildContext';
 
 bool _isSubclassOfWidget(DartType? type) =>
-    type is InterfaceType && type.allSupertypes.any(isWidget);
+    type is InterfaceType && type.allSupertypes.any(_isWidget);
 
 bool _isWidgetState(DartType? type) => type?.element?.displayName == 'State';
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
@@ -57,7 +57,7 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
   }
 
   bool _isFlutterBuilder(FunctionExpression expression) {
-    if (!isWidget(expression.declaredElement?.returnType)) {
+    if (!isWidgetOrSubclass(expression.declaredElement?.returnType)) {
       return false;
     }
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
@@ -40,7 +40,8 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
 
       if (_isNotIgnored(argument) &&
           expression is FunctionExpression &&
-          _hasNotEmptyBlockBody(expression)) {
+          _hasNotEmptyBlockBody(expression) &&
+          !_isFlutterBuilder(expression)) {
         _expressions.add(argument);
       }
     }
@@ -55,8 +56,19 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
     return body.block.statements.isNotEmpty;
   }
 
+  bool _isFlutterBuilder(FunctionExpression expression) {
+    if (!isWidget(expression.declaredElement?.returnType)) {
+      return false;
+    }
+
+    final formalParameters = expression.parameters?.parameters;
+
+    return formalParameters == null ||
+        formalParameters.isNotEmpty &&
+            isBuildContext(formalParameters.first.declaredElement?.type);
+  }
+
   bool _isNotIgnored(Expression argument) =>
       argument is! NamedExpression ||
-      (argument.name.label.name != 'builder' &&
-          !_ignoredArguments.contains(argument.name.label.name));
+      !_ignoredArguments.contains(argument.name.label.name);
 }

--- a/test/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/examples/example.dart
+++ b/test/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/examples/example.dart
@@ -56,7 +56,10 @@ class MyAnotherWidget extends StatelessWidget {
         return null;
       },
       child: Container(),
-      builder: () {
+      builder: (context) {
+        return null;
+      },
+      anotherBuilder: (context, index) {
         return null;
       },
     );
@@ -86,6 +89,8 @@ class Widget {}
 
 class StatelessWidget extends Widget {}
 
+class BuildContext {}
+
 class Container extends Widget {
   final Widget? child;
 
@@ -95,12 +100,14 @@ class Container extends Widget {
 class TextButton {
   final Widget child;
   final void Function()? onPressed;
-  final void Function()? builder;
+  final Widget Function(BuildContext)? builder;
+  final Widget Function(BuildContext, int)? anotherBuilder;
 
   const TextButton({
     required this.child,
     required this.onPressed,
     this.builder,
+    this.anotherBuilder,
   });
 }
 

--- a/test/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/examples/example.dart
+++ b/test/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/examples/example.dart
@@ -62,6 +62,9 @@ class MyAnotherWidget extends StatelessWidget {
       anotherBuilder: (context, index) {
         return null;
       },
+      myOtherWidgetBuilder: (context) {
+        return null;
+      },
     );
   }
 
@@ -102,12 +105,14 @@ class TextButton {
   final void Function()? onPressed;
   final Widget Function(BuildContext)? builder;
   final Widget Function(BuildContext, int)? anotherBuilder;
+  final MyOtherWidget Function(BuildContext, int)? myOtherWidgetBuilder;
 
   const TextButton({
     required this.child,
     required this.onPressed,
     this.builder,
     this.anotherBuilder,
+    this.myOtherWidgetBuilder,
   });
 }
 


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[x] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

### What changes did you make? (Give an overview)

It is a pretty common situation in Flutter to have "builders". Widgets even may have multiple "builder" arguments like `titleBuilder`, `contentBuilder`, etc. We are getting violations from dart code metrics on such arguments so I think it would be ok to ignore such arguments in `prefer-extracting-callbacks` rule.

### Is there anything you'd like reviewers to focus on?

I will create a separate PR to website repository with documentation updates.  It's a little bit annoying to manually keep this repository documentation and website documentation synchronized, maybe we should start thinking about avoiding this? (we can define primary documentation source somehow, for example)
