### PR TITLE
docs: add unused l10n command documentation link in readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Dart Code Metrics is a static analysis tool that helps you analyse and improve y
 - Provides [additional rules](https://dartcodemetrics.dev/docs/rules/overview) for the dart analyzer
 - Checks for [anti-patterns](https://dartcodemetrics.dev/docs/anti-patterns/overivew)
 - Checks [unused `*.dart` files](https://dartcodemetrics.dev/docs/cli/check-unused-files)
+- Checks [unused l10n](https://dartcodemetrics.dev/docs/cli/check-unused-l10n)
 - Can be used as [CLI](https://dartcodemetrics.dev/docs/cli/overview), [analyzer plugin](https://dartcodemetrics.dev/docs/analyzer-plugin) or [library](https://dartcodemetrics.dev/docs/getting-started/installation#library)
 
 ## Links


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)


### Is there anything you'd like reviewers to focus on?
