### PR TITLE
chore: restrict `analyzer` version to `>=2.4.0 <2.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.5.0-dev.3
 
 * fix: make check-unused-l10n report class fields.
+* chore: restrict `analyzer` version to `>=2.4.0 <2.8.0`.
 
 ## 4.5.0-dev.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=2.4.0 <2.7.0"
+  analyzer: ">=2.4.0 <2.8.0"
   analyzer_plugin: ^0.8.0
   ansicolor: ^2.0.1
   args: ^2.0.0


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)


### Is there anything you'd like reviewers to focus on?
