### PR TITLE
chore: restrict `analyzer` version to `>=2.4.0 <2.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 * feat: add alphabetical sorting by type for `member-ordering-extended` rule.
 * feat: add support mixins, extensions and enums for `prefer-match-file-name` rule.
-* fix: prefer conditional expressions rule breaks code with increment / decrement operators
-* chore: tune GitHub workflows
+* fix: prefer conditional expressions rule breaks code with increment / decrement operators.
+* chore: restrict `analyzer` version to `>=2.4.0 <2.9.0`.
+* chore: tune GitHub workflows.
 
 ## 4.7.0
 

--- a/lib/src/analyzer_plugin/analyzer_plugin.dart
+++ b/lib/src/analyzer_plugin/analyzer_plugin.dart
@@ -142,6 +142,7 @@ class AnalyzerPlugin extends ServerPlugin {
   ) async {
     try {
       final driver = driverForPath(parameters.file) as AnalysisDriver;
+      // ignore: deprecated_member_use
       final analysisResult = await driver.getResult2(parameters.file);
 
       if (analysisResult is! ResolvedUnitResult) {

--- a/lib/src/analyzer_plugin/analyzer_plugin_utils.dart
+++ b/lib/src/analyzer_plugin/analyzer_plugin_utils.dart
@@ -43,6 +43,7 @@ plugin.AnalysisErrorFixes codeIssueToAnalysisErrorFixes(
           plugin.SourceChange(issue.suggestion!.comment, edits: [
             plugin.SourceFileEdit(
               fileWithIssue,
+              // ignore: deprecated_member_use
               unitResult.libraryElement.source.modificationStamp,
               edits: [
                 plugin.SourceEdit(

--- a/lib/src/analyzers/lint_analyzer/lint_analyzer.dart
+++ b/lib/src/analyzers/lint_analyzer/lint_analyzer.dart
@@ -370,6 +370,6 @@ class LintAnalyzer {
     return functionRecords;
   }
 
-  bool _isSupported(AnalysisResult result) =>
+  bool _isSupported(FileResult result) =>
       result.path.endsWith('.dart') && !result.path.endsWith('.g.dart');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=2.4.0 <2.8.0"
+  analyzer: ">=2.4.0 <2.9.0"
   analyzer_plugin: ^0.8.0
   ansicolor: ^2.0.1
   args: ^2.0.0

--- a/test/src/analyzer_plugin/analyzer_plugin_utils_test.dart
+++ b/test/src/analyzer_plugin/analyzer_plugin_utils_test.dart
@@ -47,6 +47,7 @@ void main() {
         when(() => libraryElement.source).thenReturn(source);
         when(() => resolvedUnitResult.libraryElement)
             .thenReturn(libraryElement);
+        // ignore: deprecated_member_use
         when(() => source.modificationStamp).thenReturn(modificationStamp);
 
         final fixes = codeIssueToAnalysisErrorFixes(

--- a/test/src/utils/node_utils_test.dart
+++ b/test/src/utils/node_utils_test.dart
@@ -12,8 +12,6 @@ class AnnotatedNodeMock extends Mock implements AnnotatedNode {}
 
 class CompilationUnitMock extends Mock implements CompilationUnit {}
 
-class CharacterLocationMock extends Mock implements CharacterLocation {}
-
 class LineInfoMock extends Mock implements LineInfo {}
 
 class TokenMock extends Mock implements Token {}


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)


### Is there anything you'd like reviewers to focus on?
