### PR TITLE
feat: Support l10n extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * feat: facelift console reporters
 * chore: restrict `analyzer` version to `>=2.4.0 <3.1.0`.
 * chore: restrict `analyzer_plugin` version to `>=0.8.0 <0.10.0`.
+* feat: support extensions for check-unused-l10n.
 
 ## 4.8.1
 

--- a/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_visitor.dart
+++ b/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_visitor.dart
@@ -27,15 +27,16 @@ class UnusedL10nVisitor extends RecursiveAstVisitor<void> {
         target as InstanceCreationExpression,
         name,
       );
+    } else if (_matchExtension(target)) {
+      final classTarget = (target as PrefixedIdentifier).identifier;
+
+      _addMemberInvocationOnAccessor(classTarget, name);
     } else if (_matchMethodOf(target)) {
       final classTarget = (target as MethodInvocation).target;
 
       if (_matchIdentifier(classTarget)) {
         _addMemberInvocation(classTarget as SimpleIdentifier, name);
       }
-    } else if (_matchExtension(target)) {
-      final classTarget = (target as PrefixedIdentifier).identifier;
-      _addMemberInvocationOnAccessor(classTarget, name);
     }
   }
 
@@ -71,15 +72,16 @@ class UnusedL10nVisitor extends RecursiveAstVisitor<void> {
         target as InstanceCreationExpression,
         name,
       );
+    } else if (_matchExtension(target)) {
+      final classTarget = (target as PrefixedIdentifier).identifier;
+
+      _addMemberInvocationOnAccessor(classTarget, name);
     } else if (_matchMethodOf(target)) {
       final classTarget = (target as MethodInvocation).target;
 
       if (_matchIdentifier(classTarget)) {
         _addMemberInvocation(classTarget as SimpleIdentifier, name);
       }
-    } else if (_matchExtension(target)) {
-      final classTarget = (target as PrefixedIdentifier).identifier;
-      _addMemberInvocationOnAccessor(classTarget, name);
     }
   }
 
@@ -131,9 +133,11 @@ class UnusedL10nVisitor extends RecursiveAstVisitor<void> {
   void _addMemberInvocationOnAccessor(SimpleIdentifier target, String name) {
     final staticElement =
         target.staticElement?.enclosingElement as ExtensionElement;
+
     for (final element in staticElement.accessors) {
-      if (_classPattern.hasMatch(element.name) && element.isGetter) {
+      if (_classPattern.hasMatch(element.returnType.toString())) {
         final classElement = element.returnType.element;
+
         if (classElement is ClassElement) {
           _invocations.update(
             classElement,

--- a/test/resources/unused_l10n_analyzer/test_i18n.dart
+++ b/test/resources/unused_l10n_analyzer/test_i18n.dart
@@ -42,3 +42,19 @@ class S {
     return S();
   }
 }
+
+class L10nClass {
+  String method(String value) => value;
+
+  String get regularGetter => 'regular getter';
+
+  final String regularField = 'regular field';
+
+  L10nClass._();
+}
+
+class L10nWrapper {}
+
+extension L10nExtension on L10nWrapper {
+  L10nClass get l10n => L10nClass._();
+}

--- a/test/resources/unused_l10n_analyzer/unused_l10n_analyzer_example.dart
+++ b/test/resources/unused_l10n_analyzer/unused_l10n_analyzer_example.dart
@@ -8,6 +8,14 @@ void main() {
   TestI18n.of('').regularMethod('some-string');
 
   TestI18n.of('').regularField.trim();
+
+  final wrapper = L10nWrapper();
+
+  wrapper.l10n.regularField.trim();
+
+  wrapper.l10n.regularGetter;
+
+  wrapper.l10n.method('value');
 }
 
 class SomeClass {

--- a/test/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer_test.dart
+++ b/test/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer_test.dart
@@ -109,6 +109,24 @@ void main() {
         expect(result, isEmpty);
       });
 
+      test(
+        'should analyze files with custom class pattern but using extension',
+        () async {
+          final config = _createConfig(
+            analyzerExcludePatterns: analyzerExcludes,
+            classPattern: 'L10nClass',
+          );
+
+          final result = await analyzer.runCliAnalysis(
+            folders,
+            rootDirectory,
+            config,
+          );
+
+          expect(result, isEmpty);
+        },
+      );
+
       test('should return a reporter', () {
         final reporter = analyzer.getReporter(name: 'console', output: stdout);
 

--- a/test/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer_test.dart
+++ b/test/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer_test.dart
@@ -110,7 +110,7 @@ void main() {
       });
 
       test(
-        'should analyze files with custom class pattern but using extension',
+        'should analyze files with custom class name using extension',
         () async {
           final config = _createConfig(
             analyzerExcludePatterns: analyzerExcludes,


### PR DESCRIPTION
Support l10n extensions

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

- I didn't include tests because:
   - Current tests are not working on my local.
 
- Documentation is not clear about how to use `check-unused-l10n`. https://dartcodemetrics.dev/docs/cli/check-unused-l10n
The -p param would be used to find files with that pattern too, is not just for Class names.


### What changes did you make? (Give an overview)
- The changes I made were on `UnusedL10nVisitor` class, now we support unused code called from extensions, the only requirements to find unused Strings on extension are:
    -  The file name where the `Localization` is implemented should contain the name of the getter for the extension. Eg:

```dart
filename: class_with_l10n.dart

class DemoLocalizations {
  DemoLocalizations(this.localeName);

 final String localeName;
  
  String get hello {
    return Intl.message(
      'Hello World',
      name: 'hello,
      locale: localeName,
    );
  }
  ...
}
```

extension:
```dart
filename: anyname.dart

extension MyLocalizationExtension on BuildContext {
  DemoLocalizations get l10n => DemoLocalizations.of(this);
}
```
`l10n` is the name that we are going to search, then the usage will be :

```dart
flutter pub run dart_code_metrics:metrics check-unused-l10n lib -p l10n
```
Where `l10n` will find the class inside `class_with_l10n.dart` and the getter `l10n` from the extension  `MyLocalizationExtension`.

NOTE: I'm sure that you could improve this (maybe another param?).


### Is there anything you'd like reviewers to focus on?
- Yes, help me to improve the documentation and adding unit tests or any other change that this PR requires in order to improve the detection of unused l10n strings (extensions or any other class).
