### PR TITLE
fix: prefer-extracting-callbacks in nested widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * feat: support excludes for a separate anti-pattern.
+* fix: prefer-extracting-callbacks in nested widgets
 
 ## 4.9.0
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/visitor.dart
@@ -34,6 +34,8 @@ class _InstanceCreationVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    super.visitInstanceCreationExpression(node);
+
     for (final argument in node.argumentList.arguments) {
       final expression =
           argument is NamedExpression ? argument.expression : argument;

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/examples/example.dart
@@ -88,6 +88,21 @@ class MyWidgetWithEmptyCallbacks extends StatelessWidget {
   }
 }
 
+class MyWidgetWithNestedWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: TextButton(
+        // LINT
+        onPressed: () {
+          return null;
+        },
+        child: Container(),
+      ),
+    );
+  }
+}
+
 class Widget {}
 
 class StatelessWidget extends Widget {}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/prefer_extracting_callbacks_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_extracting_callbacks/prefer_extracting_callbacks_rule_test.dart
@@ -25,8 +25,8 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [11, 55],
-        startColumns: [7, 7],
+        startLines: [11, 55, 97],
+        startColumns: [7, 7, 9],
         locationTexts: [
           'onPressed: () {\n'
               '        return null;\n'
@@ -34,8 +34,12 @@ void main() {
           'onPressed: () {\n'
               '        return null;\n'
               '      }',
+          'onPressed: () {\n'
+              '          return null;\n'
+              '        }',
         ],
         messages: [
+          'Prefer extracting the callback to a separate widget method.',
           'Prefer extracting the callback to a separate widget method.',
           'Prefer extracting the callback to a separate widget method.',
         ],


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

### What changes did you make? (Give an overview)

This PR fixes `prefer-extracting-callbacks` for nested widgets.


### Is there anything you'd like reviewers to focus on?
