### PR TITLE
fix: ignore private variables in `avoid-global-state` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix: ignore private variables in `avoid-global-state` rule.
 * feat: support excludes for a separate anti-pattern.
 * chore: restrict `analyzer` version to `>=2.4.0 <3.2.0`.
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/visitor.dart
@@ -14,9 +14,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
         _declarations.add(node);
       }
     } else if ((node.declaredElement?.isStatic ?? false) &&
-        !node.isFinal &&
-        !node.isConst &&
-        !(node.declaredElement?.isPrivate ?? false)) {
+        _isNodeValid(node)) {
       _declarations.add(node);
     }
   }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/visitor.dart
@@ -10,13 +10,19 @@ class _Visitor extends RecursiveAstVisitor<void> {
     super.visitVariableDeclaration(node);
 
     if (node.declaredElement?.enclosingElement is CompilationUnitElement) {
-      if (!node.isFinal && !node.isConst) {
+      if (_isNodeValid(node)) {
         _declarations.add(node);
       }
     } else if ((node.declaredElement?.isStatic ?? false) &&
         !node.isFinal &&
-        !node.isConst) {
+        !node.isConst &&
+        !(node.declaredElement?.isPrivate ?? false)) {
       _declarations.add(node);
     }
   }
+
+  bool _isNodeValid(VariableDeclaration node) =>
+      !node.isFinal &&
+      !node.isConst &&
+      !(node.declaredElement?.isPrivate ?? false);
 }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/avoid_global_state_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/avoid_global_state_rule_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [1, 2, 10, 11, 21, 22, 32, 33],
+        startLines: [1, 2, 10, 11, 22, 23, 34, 35],
         startColumns: [5, 5, 15, 18, 15, 18, 15, 18],
         locationTexts: [
           'answer = 42',

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/examples/example.dart
@@ -14,6 +14,7 @@ class Foo {
   const d = 1;
   static const noted = '';
   static final finalField = 1;
+  static var _c3 = '';
   void function() {}
 }
 
@@ -25,6 +26,7 @@ class Mixin {
   const d = 1;
   static const noted = '';
   static final finalField = 1;
+  static var _c3 = '';
   void function() {}
 }
 
@@ -33,5 +35,6 @@ extension Extension on String {
   static dynamic c; // LINT
   static const noted = '';
   static final finalField = 1;
+  static var _c3 = '';
   void function() {}
 }


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

### What changes did you make? (Give an overview)
ignore private variables in `avoid-global-state` rule
