### PR TITLE
feat: ignore private members for check-unused-l10n command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * fix: ignore private variables in `avoid-global-state` rule.
 * feat: support excludes for a separate anti-pattern.
 * chore: restrict `analyzer` version to `>=2.4.0 <3.2.0`.
+* feat: ignore private members for `check-unused-l10n` command.
 
 ## 4.9.1
 

--- a/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer.dart
+++ b/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer.dart
@@ -168,7 +168,7 @@ class UnusedL10nAnalyzer {
     CompilationUnitElement unit,
   ) {
     final unusedAccessors = classElement.accessors
-        .where((field) => !usages.contains(field.name))
+        .where((field) => !field.isPrivate && !usages.contains(field.name))
         .map((field) => field.isSynthetic ? field.nonSynthetic : field);
 
     return unusedAccessors
@@ -182,7 +182,7 @@ class UnusedL10nAnalyzer {
     CompilationUnitElement unit,
   ) {
     final unusedMethods = classElement.methods
-        .where((method) => !usages.contains(method.name))
+        .where((method) => !method.isPrivate && !usages.contains(method.name))
         .map((method) => method.isSynthetic ? method.nonSynthetic : method);
 
     return unusedMethods

--- a/test/resources/unused_l10n_analyzer/test_i18n.dart
+++ b/test/resources/unused_l10n_analyzer/test_i18n.dart
@@ -50,6 +50,12 @@ class S {
 
   // ignore: prefer_constructors_over_static_methods
   static S get current => S();
+
+  static const _privateField = 'hello';
+
+  String get _privateGetter => 'regular getter';
+
+  String _privateMethod() => 'hi';
 }
 
 class L10nClass {


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: fix private members triggering for `check-unused-l10n`

