### PR TITLE
fix: make `check-unused-l10n` also cover supertype member calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * chore: restrict `analyzer` version to `>=2.4.0 <3.3.0`.
+* fix: make `check-unused-l10n` also cover supertype member calls.
 
 ## 4.10.0-dev.2
 

--- a/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer.dart
+++ b/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer.dart
@@ -193,6 +193,8 @@ class UnusedL10nAnalyzer {
         issues: issues,
       );
     }
+
+    return null;
   }
 
   Iterable<UnusedL10nIssue> _getUnusedAccessors(

--- a/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer.dart
+++ b/lib/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer.dart
@@ -129,24 +129,28 @@ class UnusedL10nAnalyzer {
     final unusedLocalizationIssues = <UnusedL10nFileReport>[];
 
     localizationUsages.forEach((classElement, usages) {
-      _getUnusedReports(
+      final report = _getUnusedReports(
         classElement,
-        unusedLocalizationIssues,
         usages,
         rootFolder,
       );
+      if (report != null) {
+        unusedLocalizationIssues.add(report);
+      }
 
       final hasCustomSupertype = classElement.allSupertypes.length > 1;
       if (hasCustomSupertype) {
         final supertype = classElement.supertype;
         if (supertype is InterfaceType) {
-          _getUnusedReports(
+          final report = _getUnusedReports(
             supertype.element,
-            unusedLocalizationIssues,
             usages,
             rootFolder,
             overriddenClassName: classElement.name,
           );
+          if (report != null) {
+            unusedLocalizationIssues.add(report);
+          }
         }
       }
     });
@@ -154,21 +158,20 @@ class UnusedL10nAnalyzer {
     return unusedLocalizationIssues;
   }
 
-  void _getUnusedReports(
+  UnusedL10nFileReport? _getUnusedReports(
     ClassElement classElement,
-    List<UnusedL10nFileReport> reports,
     Iterable<String> usages,
     String rootFolder, {
     String? overriddenClassName,
   }) {
     final unit = classElement.thisOrAncestorOfType<CompilationUnitElement>();
     if (unit == null) {
-      return;
+      return null;
     }
 
     final lineInfo = unit.lineInfo;
     if (lineInfo == null) {
-      return;
+      return null;
     }
 
     final accessorSourceSpans = _getUnusedAccessors(classElement, usages, unit);
@@ -183,13 +186,11 @@ class UnusedL10nAnalyzer {
     ];
 
     if (issues.isNotEmpty) {
-      reports.add(
-        UnusedL10nFileReport(
-          path: filePath,
-          relativePath: relativePath,
-          className: overriddenClassName ?? classElement.name,
-          issues: issues,
-        ),
+      return UnusedL10nFileReport(
+        path: filePath,
+        relativePath: relativePath,
+        className: overriddenClassName ?? classElement.name,
+        issues: issues,
       );
     }
   }

--- a/test/resources/unused_l10n_analyzer/base_localization.dart
+++ b/test/resources/unused_l10n_analyzer/base_localization.dart
@@ -1,0 +1,5 @@
+class BaseLocalization {
+  String get baseGetter => 'getter';
+
+  String get anotherBaseGetter => 'getter'; // LINT
+}

--- a/test/resources/unused_l10n_analyzer/test_i18n.dart
+++ b/test/resources/unused_l10n_analyzer/test_i18n.dart
@@ -1,4 +1,6 @@
-class TestI18n {
+import 'base_localization.dart';
+
+class TestI18n extends BaseLocalization {
   static const String field = 'field';
 
   static String get getter => 'getter'; // LINT

--- a/test/resources/unused_l10n_analyzer/unused_l10n_analyzer_example.dart
+++ b/test/resources/unused_l10n_analyzer/unused_l10n_analyzer_example.dart
@@ -11,6 +11,8 @@ void main() {
 
   TestI18n.of('').anotherRegularGetter;
 
+  TestI18n.of('').baseGetter;
+
   final wrapper = L10nWrapper();
 
   wrapper.l10n.regularField.trim();

--- a/test/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer_test.dart
+++ b/test/src/analyzers/unused_l10n_analyzer/unused_l10n_analyzer_test.dart
@@ -31,19 +31,17 @@ void main() {
           config,
         );
 
-        final report = result.single;
+        final report = result.firstWhere((report) => report.issues.length == 3);
         expect(report.className, 'TestI18n');
-
-        expect(report.issues.length, 3);
 
         final firstIssue = report.issues.first;
         expect(firstIssue.memberName, 'getter');
-        expect(firstIssue.location.line, 4);
+        expect(firstIssue.location.line, 6);
         expect(firstIssue.location.column, 3);
 
         final secondIssue = report.issues.elementAt(1);
         expect(secondIssue.memberName, 'regularGetter');
-        expect(secondIssue.location.line, 13);
+        expect(secondIssue.location.line, 15);
         expect(secondIssue.location.column, 3);
 
         final thirdIssue = report.issues.elementAt(2);
@@ -51,8 +49,17 @@ void main() {
           thirdIssue.memberName,
           'secondMethod(String value, num number)',
         );
-        expect(thirdIssue.location.line, 8);
+        expect(thirdIssue.location.line, 10);
         expect(thirdIssue.location.column, 3);
+
+        final parentReport =
+            result.firstWhere((report) => report.issues.length == 1);
+        expect(parentReport.className, 'TestI18n');
+
+        final firstParentIssue = parentReport.issues.first;
+        expect(firstParentIssue.memberName, 'anotherBaseGetter');
+        expect(firstParentIssue.location.line, 4);
+        expect(firstParentIssue.location.column, 3);
       });
 
       test('should analyze files with custom class pattern', () async {
@@ -74,17 +81,17 @@ void main() {
 
         final firstIssue = report.issues.first;
         expect(firstIssue.memberName, 'field');
-        expect(firstIssue.location.line, 25);
+        expect(firstIssue.location.line, 27);
         expect(firstIssue.location.column, 3);
 
         final secondIssue = report.issues.elementAt(1);
         expect(secondIssue.memberName, 'regularField');
-        expect(secondIssue.location.line, 42);
+        expect(secondIssue.location.line, 44);
         expect(secondIssue.location.column, 3);
 
         final thirdIssue = report.issues.elementAt(2);
         expect(thirdIssue.memberName, 'method(String value)');
-        expect(thirdIssue.location.line, 29);
+        expect(thirdIssue.location.line, 31);
         expect(thirdIssue.location.column, 3);
 
         final forthIssue = report.issues.elementAt(3);
@@ -92,7 +99,7 @@ void main() {
           forthIssue.memberName,
           'secondMethod(String value, num number)',
         );
-        expect(forthIssue.location.line, 31);
+        expect(forthIssue.location.line, 33);
         expect(forthIssue.location.column, 3);
       });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)


### Is there anything you'd like reviewers to focus on?
