### PR TITLE
docs: change name of metric number-of-arguments to number-of-parameters

### DIFF
--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -26,7 +26,7 @@ Basic config example:
 dart_code_metrics:
   metrics:
     cyclomatic-complexity: 20
-    number-of-arguments: 4
+    number-of-parameters: 4
     maximum-nesting-level: 5
   metrics-exclude:
     - test/**


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Documentation update

### What changes did you make? (Give an overview)

Use proper name for number-of-parameters metric in Getting started/Configuration page