### PR TITLE
fix: `check-unused-files` now ignored some system files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * feat: add new command flag `--no-congratulate`.
 * feat: add `--version` flag to print current version of the package.
+* fix: `check-unused-files` now ignored some system files.
 * fix: make `check-unused-l10n` also cover supertype member calls.
 * fix: cyclomatic complexity calculation for functions with internal lambdas.
 * chore: restrict `analyzer` version to `>=2.4.0 <3.3.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * feat: add new command flag `--no-congratulate`.
 * feat: add `--version` flag to print current version of the package.
-* fix: `check-unused-files` now ignored some system files.
+* feat: improve `check-unused-files` and `check-unused-code` commands, add support for flutter internal entry functions.
 * fix: make `check-unused-l10n` also cover supertype member calls.
 * fix: cyclomatic complexity calculation for functions with internal lambdas.
 * chore: restrict `analyzer` version to `>=2.4.0 <3.3.0`.

--- a/lib/src/analyzers/unused_files_analyzer/unused_files_analyzer.dart
+++ b/lib/src/analyzers/unused_files_analyzer/unused_files_analyzer.dart
@@ -15,6 +15,11 @@ import 'reporters/unused_files_report_params.dart';
 import 'unused_files_config.dart';
 import 'unused_files_visitor.dart';
 
+const _exceptFiles = {
+  'lib/generated_plugin_registrant.dart',
+  'test/flutter_test_config.dart',
+};
+
 /// The analyzer responsible for collecting unused files reports.
 class UnusedFilesAnalyzer {
   const UnusedFilesAnalyzer();
@@ -86,14 +91,17 @@ class UnusedFilesAnalyzer {
       }
     }
 
-    return unusedFiles.map((path) {
-      final relativePath = relative(path, from: rootFolder);
+    return unusedFiles
+        .map((path) {
+          final relativePath = relative(path, from: rootFolder);
 
-      return UnusedFilesFileReport(
-        path: path,
-        relativePath: relativePath,
-      );
-    }).toSet();
+          return UnusedFilesFileReport(
+            path: path,
+            relativePath: relativePath,
+          );
+        })
+        .toSet()
+        .difference(_exceptFiles);
   }
 
   void deleteAllUnusedFiles(Iterable<UnusedFilesFileReport> reports) {

--- a/lib/src/analyzers/unused_files_analyzer/unused_files_analyzer.dart
+++ b/lib/src/analyzers/unused_files_analyzer/unused_files_analyzer.dart
@@ -15,11 +15,6 @@ import 'reporters/unused_files_report_params.dart';
 import 'unused_files_config.dart';
 import 'unused_files_visitor.dart';
 
-const _exceptFiles = {
-  'lib/generated_plugin_registrant.dart',
-  'test/flutter_test_config.dart',
-};
-
 /// The analyzer responsible for collecting unused files reports.
 class UnusedFilesAnalyzer {
   const UnusedFilesAnalyzer();
@@ -91,17 +86,14 @@ class UnusedFilesAnalyzer {
       }
     }
 
-    return unusedFiles
-        .map((path) {
-          final relativePath = relative(path, from: rootFolder);
+    return unusedFiles.map((path) {
+      final relativePath = relative(path, from: rootFolder);
 
-          return UnusedFilesFileReport(
-            path: path,
-            relativePath: relativePath,
-          );
-        })
-        .toSet()
-        .difference(_exceptFiles);
+      return UnusedFilesFileReport(
+        path: path,
+        relativePath: relativePath,
+      );
+    }).toSet();
   }
 
   void deleteAllUnusedFiles(Iterable<UnusedFilesFileReport> reports) {

--- a/lib/src/utils/node_utils.dart
+++ b/lib/src/utils/node_utils.dart
@@ -37,7 +37,11 @@ SourceSpan nodeLocation({
 }
 
 bool isEntrypoint(String name, NodeList<Annotation> metadata) =>
-    name == 'main' || _hasPragmaAnnotation(metadata);
+    name == 'main' ||
+    _hasPragmaAnnotation(metadata) ||
+    _flutterInternalEntryFunctions.contains(name);
+
+const _flutterInternalEntryFunctions = {'registerPlugins', 'testExecutable'};
 
 /// See https://github.com/dart-lang/sdk/blob/master/runtime/docs/compiler/aot/entry_point_pragma.md
 bool _hasPragmaAnnotation(Iterable<Annotation> metadata) =>


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Command check-unused-files now triggered on some system files:

lib/generated_plugin_registrant.dart
[test/flutter_test_config.dart](https://api.flutter.dev/flutter/flutter_test/flutter_test-library.html)

that files need for correct works but never imported in project.

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)


### Is there anything you'd like reviewers to focus on?
