### PR TITLE
fix: restore `analyze` command as default command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "bools",
         "codeclimate",
         "codecov",
+        "codequality",
         "cyclomatic",
         "dartanalyzer",
         "dartdocs",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.10.1
+
+* fix: restore `analyze` command as default command.
+
 ## 4.10.0
 
 * feat: add `check-unused-code` command with monorepos support.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ To set this up:
     ```yaml
     name: dart_code_metrics_plugin_loader
     description: This pubspec determines the version of the analyzer plugin to load.
-    version: 4.10.0
+    version: 4.10.1
 
     environment:
       sdk: ">=2.14.0 <3.0.0"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ add it manually to `pubspec.yaml`
 
 ```yaml
 dev_dependencies:
-  dart_code_metrics: ^4.10.0
+  dart_code_metrics: ^4.10.1
 ```
 
 and then run

--- a/lib/src/cli/cli_runner.dart
+++ b/lib/src/cli/cli_runner.dart
@@ -38,7 +38,9 @@ class CliRunner extends CommandRunner<void> {
   @override
   Future<void> run(Iterable<String> args) async {
     try {
-      final results = parse(args);
+      final argsWithDefaultCommand = _addDefaultCommand(args);
+
+      final results = parse(argsWithDefaultCommand);
       final showVersion = results[FlagNames.version] as bool;
 
       if (showVersion) {
@@ -47,7 +49,7 @@ class CliRunner extends CommandRunner<void> {
         return;
       }
 
-      await super.run(_addDefaultCommand(args));
+      await super.run(argsWithDefaultCommand);
     } on UsageException catch (e) {
       _output
         ..writeln(e.message)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const packageVersion = '4.10.0';
+const packageVersion = '4.10.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_code_metrics
-version: 4.10.0
+version: 4.10.1
 description: Software analytics tool that helps developers analyse and improve software quality.
 homepage: https://dartcodemetrics.dev
 repository: https://github.com/dart-code-checker/dart-code-metrics

--- a/tools/analyzer_plugin/pubspec.yaml
+++ b/tools/analyzer_plugin/pubspec.yaml
@@ -1,12 +1,12 @@
 name: dart_code_metrics_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 4.10.0
+version: 4.10.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  dart_code_metrics: ^4.10.0
+  dart_code_metrics: ^4.10.1
 
 dev_dependencies:
   lints: ^1.0.1

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -374,7 +374,7 @@ code_quality:
   before_script:
     - dart pub global activate dart_code_metrics
   script:
-    - dart pub global run dart_code_metrics:metrics lib -r gitlab > code-quality-report.json
+    - dart pub global run dart_code_metrics:metrics analyze lib -r gitlab > code-quality-report.json
   artifacts:
     reports:
       codequality: code-quality-report.json

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -23,7 +23,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  dart_code_metrics: ^4.10.0
+  dart_code_metrics: ^4.10.1
 ```
 
 and then run


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)


### Is there anything you'd like reviewers to focus on?
