### PR TITLE
docs: Improve readability of no-equal-then-else description

### DIFF
--- a/website/docs/rules/common/no-equal-then-else.md
+++ b/website/docs/rules/common/no-equal-then-else.md
@@ -17,38 +17,38 @@ Warns when if statement has equal then and else statements or conditional expres
 Bad:
 
 ```dart
-final value1 = 1;
-final value2 = 2;
+final firstValue = 1;
+final secondValue = 2;
 
 ...
 
 // LINT
 if (condition) {
-  result = value1;
+  result = firstValue;
 } else {
-  result = value1;
+  result = firstValue;
 }
 
 ...
 
-result = condition ? value1 : value1; // LINT
+result = condition ? firstValue : firstValue; // LINT
 ```
 
 Good:
 
 ```dart
-final value1 = 1;
-final value2 = 2;
+final firstValue = 1;
+final secondValue = 2;
 
 ...
 
 if (condition) {
-  result = value1;
+  result = firstValue;
 } else {
-  result = value2;
+  result = secondValue;
 }
 
 ...
 
-result = condition ? value1 : value2;
+result = condition ? firstValue : secondValue;
 ```


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[X] Documentation update
[ ] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

I changed "value1" and "value2" to "firstValue" and "secondValue" in the docs for no-equal-then-else.

This change may seen small, but I've been stuck reading the two same code blocks for around 5 minutes,
trying to figure out whether the docs were wrong or I was having an aneurysm. The numbers 1 and 2 are too similar
to be easily distinguisable, but "first" and "second" have different lengths, so it should be
easier for another devs to distiguish between the two variables