### PR TITLE
fix: dart-code-metrics crash saying `Bad state: No element` when running command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* fix: dart-code-metrics crash saying `Bad state: No element` when running command.
+
 ## 4.14.0
 
 * feat: add static code diagnostic [`prefer-commenting-analyzer-ignores`](https://dartcodemetrics.dev/docs/rules/common/prefer-commenting-analyzer-ignores).

--- a/lib/src/analyzers/lint_analyzer/utils/report_utils.dart
+++ b/lib/src/analyzers/lint_analyzer/utils/report_utils.dart
@@ -15,7 +15,7 @@ MetricValueLevel maxMetricViolationLevel(Iterable<LintFileReport> records) =>
           (record) => [...record.classes.values, ...record.functions.values]
               .map((report) => report.metricsLevel),
         )
-        .max;
+        .maxOrNull ?? MetricValueLevel.none;
 
 bool hasIssueWithSeverity(
   Iterable<LintFileReport> records,

--- a/lib/src/analyzers/lint_analyzer/utils/report_utils.dart
+++ b/lib/src/analyzers/lint_analyzer/utils/report_utils.dart
@@ -15,7 +15,8 @@ MetricValueLevel maxMetricViolationLevel(Iterable<LintFileReport> records) =>
           (record) => [...record.classes.values, ...record.functions.values]
               .map((report) => report.metricsLevel),
         )
-        .maxOrNull ?? MetricValueLevel.none;
+        .maxOrNull ??
+    MetricValueLevel.none;
 
 bool hasIssueWithSeverity(
   Iterable<LintFileReport> records,


### PR DESCRIPTION
Hi thanks for this flutter-favorite package! It is crashing because of `.max` on empty array. So here is the fix.

Closes #804