### PR TITLE
docs(avoid-border-all): fix `Border.all` constructor syntax

### DIFF
--- a/website/docs/rules/flutter/avoid-border-all.md
+++ b/website/docs/rules/flutter/avoid-border-all.md
@@ -32,11 +32,11 @@ class BorderWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       //LINT
-      border: Border.all({
-        Color color = const Color(0xFF000000),
-        double width = 1.0,
-        BorderStyle style = BorderStyle.solid,
-      }),
+      border: Border.all(
+        color: const Color(0xFF000000),
+        width: 1.0,
+        style: BorderStyle.solid,
+      ),
       child: child,
     );
   }


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [x] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

Fix `Border.all` constructor arguments’ syntax.

### Is there anything you'd like reviewers to focus on?
