### PR TITLE
fix: `format-comment` is listing the macros from dart doc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix: [`format-comment`](https://dartcodemetrics.dev/docs/rules/common/format-comment) is listing the macros from dart doc.
 * fix: dart-code-metrics crash saying `Bad state: No element` when running command.
 
 ## 4.14.0

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
@@ -44,20 +44,31 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
     var text = commentText.trim();
 
-    if (text.isEmpty ||
-        text.startsWith('ignore:') ||
-        text.startsWith('ignore_for_file:')) {
-      return;
-    } else {
-      text = text.trim();
-      final upperCase = text[0] == text[0].toUpperCase();
-      final lastSymbol = _punctuation.contains(text[text.length - 1]);
-      final hasEmptySpace = commentText[0] == ' ';
-      final incorrectFormat = !upperCase || !hasEmptySpace || !lastSymbol;
-      final single = commentToken.previous == null && commentToken.next == null;
+    final isIgnoreComment =
+        text.startsWith('ignore:') || text.startsWith('ignore_for_file:');
 
-      if (incorrectFormat && single) {
-        _comments.add(_CommentInfo(type, commentToken));
+    final regTemplateExp = RegExp(r"{@template [\w'-]+}");
+    final regMacroExp = RegExp(r"{@macro [\w'-]+}");
+
+    final isMacros = regTemplateExp.hasMatch(text) ||
+        regMacroExp.hasMatch(text) ||
+        text == '{@endtemplate}';
+
+    {
+      if (text.isEmpty || isIgnoreComment || isMacros) {
+        return;
+      } else {
+        text = text.trim();
+        final upperCase = text[0] == text[0].toUpperCase();
+        final lastSymbol = _punctuation.contains(text[text.length - 1]);
+        final hasEmptySpace = commentText[0] == ' ';
+        final incorrectFormat = !upperCase || !hasEmptySpace || !lastSymbol;
+        final single =
+            commentToken.previous == null && commentToken.next == null;
+
+        if (incorrectFormat && single) {
+          _comments.add(_CommentInfo(type, commentToken));
+        }
       }
     }
   }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
@@ -5,6 +5,9 @@ const commentsOperator = {
   _CommentType.documentation: '///',
 };
 
+final _regTemplateExp = RegExp(r"{@template [\w'-]+}");
+final _regMacroExp = RegExp(r"{@macro [\w'-]+}");
+
 class _Visitor extends RecursiveAstVisitor<void> {
   final _comments = <_CommentInfo>[];
 
@@ -47,11 +50,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
     final isIgnoreComment =
         text.startsWith('ignore:') || text.startsWith('ignore_for_file:');
 
-    final regTemplateExp = RegExp(r"{@template [\w'-]+}");
-    final regMacroExp = RegExp(r"{@macro [\w'-]+}");
-
-    final isMacros = regTemplateExp.hasMatch(text) ||
-        regMacroExp.hasMatch(text) ||
+    final isMacros = _regTemplateExp.hasMatch(text) ||
+        _regMacroExp.hasMatch(text) ||
         text == '{@endtemplate}';
 
     {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
@@ -5,8 +5,10 @@ const commentsOperator = {
   _CommentType.documentation: '///',
 };
 
-final _regTemplateExp = RegExp(r"{@template [\w'-]+}");
-final _regMacroExp = RegExp(r"{@macro [\w'-]+}");
+final _regMacrosExp = RegExp('{@(template|macro) .+}');
+const _macrosEndExp = '{@endtemplate}';
+const _ignoreExp = 'ignore:';
+const _ignoreForFileExp = 'ignore_for_file:';
 
 class _Visitor extends RecursiveAstVisitor<void> {
   final _comments = <_CommentInfo>[];
@@ -48,11 +50,9 @@ class _Visitor extends RecursiveAstVisitor<void> {
     var text = commentText.trim();
 
     final isIgnoreComment =
-        text.startsWith('ignore:') || text.startsWith('ignore_for_file:');
+        text.startsWith(_ignoreExp) || text.startsWith(_ignoreForFileExp);
 
-    final isMacros = _regTemplateExp.hasMatch(text) ||
-        _regMacroExp.hasMatch(text) ||
-        text == '{@endtemplate}';
+    final isMacros = _regMacrosExp.hasMatch(text) || text == _macrosEndExp;
 
     {
       if (text.isEmpty || isIgnoreComment || isMacros) {

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/format_comment/examples/example_documentation.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/format_comment/examples/example_documentation.dart
@@ -16,3 +16,12 @@ void greet(String name) {
 
 /// deletes the file at [path] from the file system.
 void delete(String path) {}
+
+/// {@template template_name}
+void f1() {}
+
+/// {@endtemplate}
+void f2() {}
+
+/// {@macro template_name}
+void f3() {}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/format_comment/examples/example_documentation.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/format_comment/examples/example_documentation.dart
@@ -25,3 +25,6 @@ void f2() {}
 
 /// {@macro template_name}
 void f3() {}
+
+/// {@template my_project.my_class.my_method}
+void f4() {}


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[X] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->
https://github.com/dart-code-checker/dart-code-metrics/issues/812
<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)


### Is there anything you'd like reviewers to focus on?
