### PR TITLE
feat: remove declaration in prefer-immediate-return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * fix: dart-code-metrics crash saying `Bad state: No element` when running command.
+* feat: remove declaration in prefer-immediate-return
 
 ## 4.14.0
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_immediate_return/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_immediate_return/visitor.dart
@@ -33,7 +33,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
     }
 
     _issues.add(_IssueDetails(
-      lastDeclaredVariable.initializer,
+      lastDeclaredVariable,
       returnStatement,
     ));
   }
@@ -41,10 +41,10 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
 class _IssueDetails {
   const _IssueDetails(
-    this.variableDeclarationInitializer,
+    this.variableDeclaration,
     this.returnStatement,
   );
 
-  final Expression? variableDeclarationInitializer;
+  final VariableDeclaration variableDeclaration;
   final ReturnStatement returnStatement;
 }

--- a/lib/src/utils/node_utils.dart
+++ b/lib/src/utils/node_utils.dart
@@ -8,12 +8,13 @@ import '../analyzers/lint_analyzer/models/internal_resolved_unit_result.dart';
 SourceSpan nodeLocation({
   required SyntacticEntity node,
   required InternalResolvedUnitResult source,
+  SyntacticEntity? endNode,
   bool withCommentOrMetadata = false,
 }) {
   final offset = !withCommentOrMetadata && node is AnnotatedNode
       ? node.firstTokenAfterCommentAndMetadata.offset
       : node.offset;
-  final end = node.end;
+  final end = endNode?.end ?? node.end;
   final sourceUrl = Uri.file(source.path);
 
   final offsetLocation = source.lineInfo.getLocation(offset);

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_immediate_return/prefer_immediate_return_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_immediate_return/prefer_immediate_return_rule_test.dart
@@ -28,15 +28,15 @@ void main() {
         RuleTestHelper.verifyIssues(
           issues: issues,
           startLines: [
-            4,
+            2,
             10,
             16,
-            23,
-            30,
-            49,
-            53,
-            63,
-            68,
+            21,
+            28,
+            47,
+            51,
+            61,
+            66,
           ],
           startColumns: [
             3,
@@ -83,15 +83,29 @@ void main() {
             'return a + b;',
           ],
           locationTexts: [
+            'final sum = a + b;\n'
+                '\n'
+                '  return sum;',
             'return sum;',
             'return sum;',
-            'return sum;',
-            'return result;',
-            'return x;',
-            'return sum;',
-            'return sum;',
-            'return result;',
-            'return result;',
+            'final result = width * height;\n'
+                '\n'
+                '    return result;',
+            'final String? x;\n'
+                '\n'
+                '  return x;',
+            'final sum = a + b;\n'
+                '\n'
+                '    return sum;',
+            'final sum = 0;\n'
+                '\n'
+                '    return sum;',
+            'final result = a * b;\n'
+                '\n'
+                '    return result;',
+            'final result = a + b;\n'
+                '\n'
+                '    return result;',
           ],
         );
       });


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[x] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

### What changes did you make? (Give an overview)

`prefer-immediate-return` will remove variable declaration as well, if this is a single declaration (e.g. it will remove `final x = 1` but not `final a = 2, x = 1`).

It will solve the most common use case, when there's a single variable declaration and immediate return.

### Is there anything you'd like reviewers to focus on?
