### PR TITLE
feat: Add the option `ignored-patterns` to the rule `format-comment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* feat: add `ignored-patterns` option to [`format-comment`](https://dartcodemetrics.dev/docs/rules/common/format-comment). The given regular expression will be used to ignore comments that match them.
+* feat: add the `ignored-patterns` option to [`format-comment`](https://dartcodemetrics.dev/docs/rules/common/format-comment). The given regular expressions will be used to ignore comments that match them.
 
 ## 4.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* feat: add `ignored-patterns` option to [`format-comment`](https://dartcodemetrics.dev/docs/rules/common/format-comment). The given regular expression will be used to ignore comments that match them.
+
 ## 4.15.0
 
 * fix: [`format-comment`](https://dartcodemetrics.dev/docs/rules/common/format-comment) is listing the macros from dart doc.

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/config_parser.dart
@@ -1,0 +1,12 @@
+part of 'format_comment_rule.dart';
+
+class _ConfigParser {
+  static const _ignoredPatternsConfig = 'ignored-patterns';
+
+  static Iterable<RegExp> getIgnoredPatterns(Map<String, Object> config) =>
+      config[_ignoredPatternsConfig] is Iterable
+          ? List<String>.from(
+              config[_ignoredPatternsConfig] as Iterable? ?? const <String>[],
+            ).map((stringPattern) => RegExp(stringPattern))
+          : const [];
+}

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/config_parser.dart
@@ -6,7 +6,7 @@ class _ConfigParser {
   static Iterable<RegExp> getIgnoredPatterns(Map<String, Object> config) =>
       config[_ignoredPatternsConfig] is Iterable
           ? List<String>.from(
-              config[_ignoredPatternsConfig] as Iterable? ?? const <String>[],
+              config[_ignoredPatternsConfig] as Iterable,
             ).map((stringPattern) => RegExp(stringPattern))
           : const [];
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_rule.dart
@@ -33,7 +33,8 @@ class FormatCommentRule extends CommonRule {
           excludes: readExcludes(config),
         );
 
-  /// The patterns to ignore. The patterns are used as [RegExp]s.
+  /// The patterns to ignore. They are used to ignore and not lint comments that
+  /// match at least one of them.
   final Iterable<RegExp> _ignoredPatterns;
 
   @override

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_rule.dart
@@ -12,10 +12,9 @@ import '../../../models/severity.dart';
 import '../../models/common_rule.dart';
 import '../../rule_utils.dart';
 
+part 'config_parser.dart';
 part 'models/comment_info.dart';
-
 part 'models/comment_type.dart';
-
 part 'visitor.dart';
 
 class FormatCommentRule extends CommonRule {
@@ -24,9 +23,7 @@ class FormatCommentRule extends CommonRule {
   static const _warning = 'Prefer formatting comments like sentences.';
 
   FormatCommentRule([Map<String, Object> config = const {}])
-      : _ignoredPatterns = List<String>.from(
-          config['ignored-patterns'] as List? ?? const <String>[],
-        ).map((stringPattern) => RegExp(stringPattern)),
+      : _ignoredPatterns = _ConfigParser.getIgnoredPatterns(config),
         super(
           id: ruleId,
           severity: readSeverity(config, Severity.style),

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_rule.dart
@@ -24,15 +24,21 @@ class FormatCommentRule extends CommonRule {
   static const _warning = 'Prefer formatting comments like sentences.';
 
   FormatCommentRule([Map<String, Object> config = const {}])
-      : super(
+      : _ignoredPatterns = List<String>.from(
+          config['ignored-patterns'] as List? ?? const <String>[],
+        ).map((stringPattern) => RegExp(stringPattern)),
+        super(
           id: ruleId,
           severity: readSeverity(config, Severity.style),
           excludes: readExcludes(config),
         );
 
+  /// The patterns to ignore. The patterns are used as [RegExp]s.
+  final Iterable<RegExp> _ignoredPatterns;
+
   @override
   Iterable<Issue> check(InternalResolvedUnitResult source) {
-    final visitor = _Visitor()..checkComments(source.unit.root);
+    final visitor = _Visitor(_ignoredPatterns)..checkComments(source.unit.root);
 
     return [
       for (final comment in visitor.comments)

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_rule.dart
@@ -22,6 +22,10 @@ class FormatCommentRule extends CommonRule {
 
   static const _warning = 'Prefer formatting comments like sentences.';
 
+  /// The patterns to ignore. They are used to ignore and not lint comments that
+  /// match at least one of them.
+  final Iterable<RegExp> _ignoredPatterns;
+
   FormatCommentRule([Map<String, Object> config = const {}])
       : _ignoredPatterns = _ConfigParser.getIgnoredPatterns(config),
         super(
@@ -29,10 +33,6 @@ class FormatCommentRule extends CommonRule {
           severity: readSeverity(config, Severity.style),
           excludes: readExcludes(config),
         );
-
-  /// The patterns to ignore. They are used to ignore and not lint comments that
-  /// match at least one of them.
-  final Iterable<RegExp> _ignoredPatterns;
 
   @override
   Iterable<Issue> check(InternalResolvedUnitResult source) {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
@@ -11,6 +11,9 @@ const _ignoreExp = 'ignore:';
 const _ignoreForFileExp = 'ignore_for_file:';
 
 class _Visitor extends RecursiveAstVisitor<void> {
+  _Visitor(this._ignoredPatterns);
+
+  final Iterable<RegExp> _ignoredPatterns;
   final _comments = <_CommentInfo>[];
 
   Iterable<_CommentInfo> get comments => _comments;
@@ -54,8 +57,12 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
     final isMacros = _regMacrosExp.hasMatch(text) || text == _macrosEndExp;
 
+    final isAnIgnoredPattern = _ignoredPatterns.any(
+      (regExp) => regExp.hasMatch(text),
+    );
+
     {
-      if (text.isEmpty || isIgnoreComment || isMacros) {
+      if (text.isEmpty || isIgnoreComment || isMacros || isAnIgnoredPattern) {
         return;
       } else {
         text = text.trim();

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
@@ -14,6 +14,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
   _Visitor(this._ignoredPatterns);
 
   final Iterable<RegExp> _ignoredPatterns;
+
   final _comments = <_CommentInfo>[];
 
   Iterable<_CommentInfo> get comments => _comments;

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
@@ -11,9 +11,9 @@ const _ignoreExp = 'ignore:';
 const _ignoreForFileExp = 'ignore_for_file:';
 
 class _Visitor extends RecursiveAstVisitor<void> {
-  _Visitor(this._ignoredPatterns);
-
   final Iterable<RegExp> _ignoredPatterns;
+
+  _Visitor(this._ignoredPatterns);
 
   final _comments = <_CommentInfo>[];
 

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/format_comment/format_comment_test.dart
@@ -89,5 +89,39 @@ void main() {
       final unit = await RuleTestHelper.resolveFromFile(_withoutIssuePath);
       RuleTestHelper.verifyNoIssues(FormatCommentRule().check(unit));
     });
+
+    test('ignores the given patterns', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = FormatCommentRule(const {
+        'ignored-patterns': [
+          // Ignores all the comments that start with 'Without'.
+          r'^Without.*$',
+        ],
+      }).check(unit);
+
+      RuleTestHelper.verifyIssues(
+        issues: issues,
+        startLines: [1, 5, 8, 10],
+        startColumns: [1, 5, 3, 5],
+        locationTexts: [
+          '// With start space without dot',
+          '// with start space with dot.',
+          '/// With start space without dot',
+          '/// with start space with dot.',
+        ],
+        messages: [
+          'Prefer formatting comments like sentences.',
+          'Prefer formatting comments like sentences.',
+          'Prefer formatting comments like sentences.',
+          'Prefer formatting comments like sentences.',
+        ],
+        replacements: [
+          '// With start space without dot.',
+          '// With start space with dot.',
+          '/// With start space without dot.',
+          '/// With start space with dot.',
+        ],
+      );
+    });
   });
 }

--- a/website/docs/rules/common/format-comment.md
+++ b/website/docs/rules/common/format-comment.md
@@ -1,5 +1,7 @@
 # Format comments
 
+![Configurable](https://img.shields.io/badge/-configurable-informational)
+
 ## Rule id {#rule-id}
 
 format-comment
@@ -11,6 +13,20 @@ Style
 ## Description {#description}
 
 Prefer format comments like sentences.
+
+Use `ignored-patterns` configuration, if you want to ignore comments that match the given regular expressions.
+
+### Config example {#config-example}
+
+```yaml
+dart_code_metrics:
+  ...
+  rules:
+    ...
+    - format-comment:
+        ignored-patterns:
+          - ^ cSpell.*  # Ignores all the comments that start with 'cSpell' (for example: '// cSpell:disable-next-line').
+```
 
 ### Example {#example}
 

--- a/website/docs/rules/overview.md
+++ b/website/docs/rules/overview.md
@@ -79,7 +79,7 @@ Rules configuration is [described here](../getting-started/configuration#configu
 
     Checks that double literals should begin with `0.` instead of just `.`, and should not end with a trailing `0`.
 
-- [format-comment](./common/format-comment.md) &nbsp; ![Has auto-fix](https://img.shields.io/badge/-has%20auto--fix-success)
+- [format-comment](./common/format-comment.md) &nbsp; [![Configurable](https://img.shields.io/badge/-configurable-informational)](./common/format-comment.md#config-example) ![Has auto-fix](https://img.shields.io/badge/-has%20auto--fix-success)
 
   Prefer format comments like sentences.
 


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[x] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

Should close https://github.com/dart-code-checker/dart-code-metrics/issues/826

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

I added the option `ignored-patterns` (a list of strings that will be used as regexes) to the rule `format-comment` to be able to ignore some kind of comments.


### Is there anything you'd like reviewers to focus on?

Am I correctly getting the `ignored-patterns` option from the `config` ? I didn't find how to test it myself (e2e test) and make sure my code is actually working.


Also, do I have to apply any change to your web site? If yes, how?
