### PR TITLE
fix: avoid-top-level-members-in-tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * chore: restrict `analyzer` version to `>=4.1.0 <4.4.0`.
 * chore: restrict `analyzer_plugin` version to `>=0.11.0 <0.12.0`.
+* fix: avoid-top-level-members-in-tests ignore lib
 
 ## 4.17.0
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_top_level_members_in_tests/avoid_top_level_members_in_tests_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_top_level_members_in_tests/avoid_top_level_members_in_tests_rule.dart
@@ -22,7 +22,7 @@ class AvoidTopLevelMembersInTestsRule extends CommonRule {
       : super(
           id: ruleId,
           severity: readSeverity(config, Severity.warning),
-          excludes: ['!test/**'],
+          excludes: ['/**', '!test/**'],
         );
 
   @override


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

Issues: https://github.com/dart-code-checker/dart-code-metrics/issues/944

### What changes did you make? (Give an overview)

I added all the folders (`'*'`) so that only the test folder is taken into account.

### Is there anything you'd like reviewers to focus on?

I tried to do a test to see if the file was being ignored, but I have the impression that the exclusion is done in another part of the code.

As it stands, this is the only rule that doesn't take excludes in parameters.
Is this normal?
We could add the excludes of the config or replace the existing excludes.
