### PR TITLE
chore: restrict `analyzer` version to `>=4.1.0 <4.7.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 
+## Unreleased
+
+* chore: restrict `analyzer` version to `>=4.1.0 <4.7.0`.
+
 ## 4.18.0-dev.1
 
 * chore: restrict `analyzer` version to `>=4.1.0 <4.5.0`.
 * chore: restrict `analyzer_plugin` version to `>=0.11.0 <0.12.0`.
+
+## 4.17.1
+
+* chore: restrict `analyzer` version to `>=4.0.0 <4.7.0`.
 
 ## 4.17.0
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_global_state/visitor.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 part of 'avoid_global_state_rule.dart';
 
 class _Visitor extends RecursiveAstVisitor<void> {
@@ -9,7 +11,6 @@ class _Visitor extends RecursiveAstVisitor<void> {
   void visitVariableDeclaration(VariableDeclaration node) {
     super.visitVariableDeclaration(node);
 
-    // ignore: deprecated_member_use
     if (node.declaredElement?.enclosingElement is CompilationUnitElement) {
       if (_isNodeValid(node)) {
         _declarations.add(node);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=4.1.0 <4.5.0"
+  analyzer: ">=4.1.0 <4.7.0"
   analyzer_plugin: ">=0.11.0 <0.12.0"
   ansicolor: ^2.0.1
   args: ^2.0.0


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

### Is there anything you'd like reviewers to focus on?
