### PR TITLE
feat: avoid passing async when sync expected

### DIFF
--- a/lib/src/analyzers/lint_analyzer/rules/rules_factory.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_factory.dart
@@ -13,6 +13,7 @@ import 'rules_list/avoid_missing_enum_constant_in_map/avoid_missing_enum_constan
 import 'rules_list/avoid_nested_conditional_expressions/avoid_nested_conditional_expressions_rule.dart';
 import 'rules_list/avoid_non_ascii_symbols/avoid_non_ascii_symbols_rule.dart';
 import 'rules_list/avoid_non_null_assertion/avoid_non_null_assertion_rule.dart';
+import 'rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected.dart';
 import 'rules_list/avoid_preserve_whitespace_false/avoid_preserve_whitespace_false_rule.dart';
 import 'rules_list/avoid_returning_widgets/avoid_returning_widgets_rule.dart';
 import 'rules_list/avoid_shrink_wrap_in_lists/avoid_shrink_wrap_in_lists_rule.dart';
@@ -76,6 +77,8 @@ final _implementedRules = <String, Rule Function(Map<String, Object>)>{
       AvoidNestedConditionalExpressionsRule.new,
   AvoidNonAsciiSymbolsRule.ruleId: AvoidNonAsciiSymbolsRule.new,
   AvoidNonNullAssertionRule.ruleId: AvoidNonNullAssertionRule.new,
+  AvoidPassingAsyncWhenSyncExpectedRule.ruleId:
+      AvoidPassingAsyncWhenSyncExpectedRule.new,
   AvoidPreserveWhitespaceFalseRule.ruleId: AvoidPreserveWhitespaceFalseRule.new,
   AvoidReturningWidgetsRule.ruleId: AvoidReturningWidgetsRule.new,
   AvoidShrinkWrapInListsRule.ruleId: AvoidShrinkWrapInListsRule.new,

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected.dart
@@ -1,0 +1,46 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+import '../../../../../utils/node_utils.dart';
+import '../../../lint_utils.dart';
+import '../../../models/internal_resolved_unit_result.dart';
+import '../../../models/issue.dart';
+import '../../../models/severity.dart';
+import '../../models/common_rule.dart';
+import '../../rule_utils.dart';
+
+part 'visitor.dart';
+
+class AvoidPassingAsyncWhenSyncExpectedRule extends CommonRule {
+  static const String ruleId = 'avoid-passing-async-when-sync-expected';
+
+  static const _warningMessage = 'Expected a sync function but got async.';
+
+  AvoidPassingAsyncWhenSyncExpectedRule([Map<String, Object> config = const {}])
+      : super(
+          id: ruleId,
+          severity: readSeverity(config, Severity.warning),
+          excludes: readExcludes(config),
+        );
+
+  @override
+  Iterable<Issue> check(InternalResolvedUnitResult source) {
+    final visitor = _Visitor();
+
+    source.unit.visitChildren(visitor);
+
+    return visitor.invalidArguments
+        .map((invocation) => createIssue(
+              rule: this,
+              location: nodeLocation(
+                node: invocation,
+                source: source,
+              ),
+              message: _warningMessage,
+            ))
+        .toList(growable: false);
+  }
+}

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/visitor.dart
@@ -1,0 +1,38 @@
+part of 'avoid_passing_async_when_sync_expected.dart';
+
+class _Visitor extends RecursiveAstVisitor<void> {
+  final _invalidArguments = <Expression>[];
+
+  Iterable<Expression> get invalidArguments => _invalidArguments;
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    super.visitInstanceCreationExpression(node);
+    _handleInvalidArguments(node.argumentList);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    super.visitMethodInvocation(node);
+    _handleInvalidArguments(node.argumentList);
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    super.visitFunctionExpressionInvocation(node);
+    _handleInvalidArguments(node.argumentList);
+  }
+
+  void _handleInvalidArguments(ArgumentList arguments) {
+    for (final argument in arguments.arguments) {
+      final argumentType = argument.staticType;
+      final parameterType = argument.staticParameterElement?.type;
+      if (argumentType is FunctionType && parameterType is FunctionType) {
+        if (argumentType.returnType.isDartAsyncFuture &&
+            !parameterType.returnType.isDartAsyncFuture) {
+          _invalidArguments.add(argument);
+        }
+      }
+    }
+  }
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected.dart
@@ -1,0 +1,46 @@
+import 'package:dart_code_metrics/src/analyzers/lint_analyzer/models/severity.dart';
+import 'package:dart_code_metrics/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected.dart';
+import 'package:test/test.dart';
+
+import '../../../../../helpers/rule_test_helper.dart';
+
+const _examplePath =
+    'avoid_passing_async_when_sync_expected/examples/example.dart';
+
+void main() {
+  group('AvoidPassingAsyncWhenSyncExpectedRule', () {
+    test('initialization', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = AvoidPassingAsyncWhenSyncExpectedRule().check(unit);
+
+      RuleTestHelper.verifyInitialization(
+        issues: issues,
+        ruleId: AvoidPassingAsyncWhenSyncExpectedRule.ruleId,
+        severity: Severity.warning,
+      );
+    });
+
+    test('reports about found issues', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = AvoidPassingAsyncWhenSyncExpectedRule().check(unit);
+
+      RuleTestHelper.verifyIssues(
+        issues: issues,
+        startLines: [50, 55, 58, 101],
+        startColumns: [7, 7, 7, 9],
+        locationTexts: [
+          'synchronousWork: work1,',
+          'synchronousWork3: () async {',
+          'synchronousWork4: work4,',
+          'onPressed: () async {',
+        ],
+        messages: [
+          'Expected a sync function but got async.',
+          'Expected a sync function but got async.',
+          'Expected a sync function but got async.',
+          'Expected a sync function but got async.',
+        ],
+      );
+    });
+  });
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/examples/example.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({Key? key, required this.title}) : super(key: key);
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    initialize();
+  }
+
+  void initialize() {
+    final work1 = () async {
+      print('hello');
+    };
+
+    Future<void> work4() async {
+      print('work4');
+    }
+
+    aSyncFunction(
+      synchronousWork: work1, // LINT
+      synchronousWork2: () {
+        print('work 2');
+      },
+      // LINT
+      synchronousWork3: () async {
+        print('work 3');
+      },
+      synchronousWork4: work4,
+    );
+  }
+
+  void aSyncFunction({
+    required VoidCallback synchronousWork,
+    required VoidCallback synchronousWork2,
+    required VoidCallback synchronousWork3,
+    required VoidCallback synchronousWork4,
+  }) {
+    synchronousWork();
+    synchronousWork2();
+    synchronousWork3();
+    synchronousWork4();
+  }
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'You have pushed the button this many times:',
+            ),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headline4,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await Future.delayed(const Duration(seconds: 1));
+          _incrementCounter();
+        },
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/website/docs/rules/common/avoid-passing-async-when-sync-expected.mdx
+++ b/website/docs/rules/common/avoid-passing-async-when-sync-expected.mdx
@@ -1,0 +1,40 @@
+import RuleDetails from '@site/src/components/RuleDetails';
+
+<RuleDetails version="4.18.0" severity="warning" />
+
+Avoid passing asynchronous function as an argument where a synchronous function is expected.
+
+### Example {#example}
+
+**❌ Bad:**
+
+```dart
+void doSomethingWithCallback(VoidCallback function) {
+  ...
+  function();
+  ...
+}
+
+void main() {
+  doSomethingWithCallback(() async {
+    await Future.delayed(Duration(seconds: 1));
+    print('Hello World');
+  });
+}
+```
+
+**✅ Good:**
+
+```dart
+void doSomethingWithCallback(VoidCallback function) {
+  ...
+  function();
+  ...
+}
+
+void main() {
+  doSomethingWithCallback(() {
+    print('Hello World');
+  });
+}
+```

--- a/website/docs/rules/index.mdx
+++ b/website/docs/rules/index.mdx
@@ -123,6 +123,16 @@ Rules are grouped by category to help you understand their purpose. Each rule ha
 </RuleEntry>
 
 <RuleEntry
+  name="avoid-passing-async-when-sync-expected"
+  type="common"
+  severity="warning"
+  version="4.18.0"
+>
+  Warns when an asynchronous function is used as an argument where a synchronous
+  function is expected.
+</RuleEntry>
+
+<RuleEntry
   name="avoid-throw-in-catch-block"
   type="common"
   severity="warning"


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [x] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

I've added a new rule, `avoid-passing-async-when-sync-expected`, which warns the user about async functions being passed as argument where a sync function was expected. This is helpful because the function won't be awaited as the user may expect.

#886

### Is there anything you'd like reviewers to focus on?

Please, feel free to give advice on any other way to write the same rule in a more elegant way. I'm not familiar with the analyzer API xD.