### PR TITLE
fix: make avoid-border-all not report errors on final variables

### DIFF
--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_border_all/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_border_all/visitor.dart
@@ -29,6 +29,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
           final element = arg.staticElement;
           if (element is PropertyAccessorElement && !element.variable.isConst) {
             isAllConst = false;
+          } else if (element is VariableElement && !element.isConst) {
+            isAllConst = false;
           }
         }
       }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_border_all/avoid_border_all_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_border_all/avoid_border_all_rule_test.dart
@@ -5,6 +5,8 @@ import 'package:test/test.dart';
 import '../../../../../helpers/rule_test_helper.dart';
 
 const _examplePath = 'avoid_border_all/examples/example.dart';
+const _exampleWithVariablesPath =
+    'avoid_border_all/examples/example_with_variables..dart';
 
 void main() {
   group('AvoidBorderAllRule', () {
@@ -61,6 +63,15 @@ void main() {
           'Prefer using const constructor Border.fromBorderSide.',
         ],
       );
+    });
+
+    test('does not report a issue when final variable is used as argument',
+        () async {
+      final unit =
+          await RuleTestHelper.resolveFromFile(_exampleWithVariablesPath);
+      final issues = AvoidBorderAllRule().check(unit);
+
+      RuleTestHelper.verifyNoIssues(issues);
     });
   });
 }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_border_all/examples/example_with_final_variables.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_border_all/examples/example_with_final_variables.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final boolean = MediaQuery.of(context).size.width > 300;
+    final aLocalColor = boolean ? Colors.red : Colors.black;
+
+    return MaterialApp(
+      home: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: aLocalColor),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

I've made the following code not trigger warnings:
```dart
final aLocalColor = Colors.red;
Border.all(color: aLocalColor);
```

#973.

### Is there anything you'd like reviewers to focus on?

I would like to know If there's any way that we could refactor this rule such that we didn't have to cover each and every case separately.