### PR TITLE
fix: make avoid-wrapping-in-padding trigger only on Container widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.19.1
+
+* fix: make [`avoid-wrapping-in-padding`](https://dartcodemetrics.dev/docs/rules/flutter/avoid-wrapping-in-padding) trigger only on Container widget.
+
 ## 4.19.0
 
 * feat: add static code diagnostic [`check-for-equals-in-render-object-setters`](https://dartcodemetrics.dev/docs/rules/flutter/check-for-equals-in-render-object-setters).

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_wrapping_in_padding/avoid_wrapping_in_padding_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_wrapping_in_padding/avoid_wrapping_in_padding_rule.dart
@@ -2,7 +2,6 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart';
 
 import '../../../../../utils/flutter_types_utils.dart';
@@ -19,8 +18,7 @@ part 'visitor.dart';
 class AvoidWrappingInPaddingRule extends FlutterRule {
   static const String ruleId = 'avoid-wrapping-in-padding';
 
-  static const _warning =
-      'Avoid wrapping a widget with padding settings in a Padding widget.';
+  static const _warning = 'Avoid wrapping a Container in a Padding widget.';
 
   AvoidWrappingInPaddingRule([Map<String, Object> config = const {}])
       : super(

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_wrapping_in_padding/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_wrapping_in_padding/visitor.dart
@@ -23,14 +23,10 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
     if (child != null && child is NamedExpression) {
       final expression = child.expression;
-      if (expression is InstanceCreationExpression) {
-        final element = expression.staticType?.element;
-        if (element is ClassElement) {
-          return element.fields
-                  .firstWhereOrNull((filed) => filed.name == 'padding') !=
-              null;
-        }
-      }
+
+      return expression is InstanceCreationExpression &&
+          expression.staticType?.getDisplayString(withNullability: false) ==
+              'Container';
     }
 
     return false;

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_wrapping_in_padding/avoid_wrapping_in_padding_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_wrapping_in_padding/avoid_wrapping_in_padding_rule_test.dart
@@ -33,7 +33,7 @@ void main() {
               '    )',
         ],
         messages: [
-          'Avoid wrapping a widget with padding settings in a Padding widget.',
+          'Avoid wrapping a Container in a Padding widget.',
         ],
       );
     });


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

#1001 
