### PR TITLE
fix: make avoid-redundant-async correctly handle nullable return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.19.1
+
+* fix: make [`avoid-redundant-async`](https://dartcodemetrics.dev/docs/rules/common/avoid-redundant-async) correctly handle nullable return values.
+
 ## 4.19.0
 
 * feat: add static code diagnostic [`check-for-equals-in-render-object-setters`](https://dartcodemetrics.dev/docs/rules/flutter/check-for-equals-in-render-object-setters).

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_redundant_async/avoid_redundant_async_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_redundant_async/avoid_redundant_async_rule.dart
@@ -3,6 +3,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 
 import '../../../../../utils/node_utils.dart';
 import '../../../lint_utils.dart';

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_redundant_async/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_redundant_async/visitor.dart
@@ -53,7 +53,9 @@ class _AsyncVisitor extends RecursiveAstVisitor<void> {
 
     final type = node.expression?.staticType;
 
-    if (type == null || !type.isDartAsyncFuture) {
+    if (type == null ||
+        !type.isDartAsyncFuture ||
+        type.nullabilitySuffix == NullabilitySuffix.question) {
       hasValidAsync = true;
     }
   }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_redundant_async/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_redundant_async/examples/example.dart
@@ -30,4 +30,8 @@ class SomeClass {
 
     print(records);
   }
+
+  Future<void> returnNullable(SomeClass? instance) async {
+    return instance?.report([]);
+  }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

#1006 
