### PR TITLE
feat: add 'include-methods' config to 'missing-test-assertion' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* feat: add 'include-methods' config to static code diagnostic [`missing-test-assertion`](https://dartcodemetrics.dev/docs/rules/common/missing-test-assertion)
 * fix: add rule 'missing-test-assertion' in rules factory.
 * feat: add static code diagnostic [`missing-test-assertion`](https://dartcodemetrics.dev/docs/rules/common/missing-test-assertion).
 * feat: add support for presets

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/config_parser.dart
@@ -2,10 +2,17 @@ part of 'missing_test_assertion_rule.dart';
 
 class _ConfigParser {
   static const _includeAssertionsConfig = 'include-assertions';
+  static const _includeMethodsConfig = 'include-methods';
 
   static Iterable<String> parseIncludeAssertions(Map<String, Object> config) =>
       config.containsKey(_includeAssertionsConfig) &&
               config[_includeAssertionsConfig] is Iterable
           ? List<String>.from(config[_includeAssertionsConfig] as Iterable)
+          : <String>[];
+
+  static Iterable<String> parseIncludeMethods(Map<String, Object> config) =>
+      config.containsKey(_includeMethodsConfig) &&
+              config[_includeMethodsConfig] is Iterable
+          ? List<String>.from(config[_includeMethodsConfig] as Iterable)
           : <String>[];
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/missing_test_assertion_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/missing_test_assertion_rule.dart
@@ -12,6 +12,7 @@ import '../../models/common_rule.dart';
 import '../../rule_utils.dart';
 
 part 'config_parser.dart';
+
 part 'visitor.dart';
 
 class MissingTestAssertionRule extends CommonRule {
@@ -20,9 +21,11 @@ class MissingTestAssertionRule extends CommonRule {
   static const _warningMessage = 'Missing test assertion.';
 
   final Iterable<String> _includeAssertions;
+  final Iterable<String> _includeMethods;
 
   MissingTestAssertionRule([Map<String, Object> config = const {}])
       : _includeAssertions = _ConfigParser.parseIncludeAssertions(config),
+        _includeMethods = _ConfigParser.parseIncludeMethods(config),
         super(
           id: ruleId,
           severity: readSeverity(config, Severity.warning),
@@ -32,7 +35,7 @@ class MissingTestAssertionRule extends CommonRule {
 
   @override
   Iterable<Issue> check(InternalResolvedUnitResult source) {
-    final visitor = _Visitor(_includeAssertions);
+    final visitor = _Visitor(_includeAssertions, _includeMethods);
 
     source.unit.visitChildren(visitor);
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/visitor.dart
@@ -6,8 +6,9 @@ class _Visitor extends RecursiveAstVisitor<void> {
   Iterable<AstNode> get nodes => _nodes;
 
   final Iterable<String> _includeAssertions;
+  final Iterable<String> _includeMethods;
 
-  _Visitor(this._includeAssertions);
+  _Visitor(this._includeAssertions, this._includeMethods);
 
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
@@ -16,14 +17,14 @@ class _Visitor extends RecursiveAstVisitor<void> {
       return;
     }
 
-    final visitor = _MethodTestVisitor(_includeAssertions);
+    final visitor = _MethodTestVisitor(_includeAssertions, _includeMethods);
     node.visitChildren(visitor);
     _nodes.addAll(visitor.nodes);
   }
 }
 
 class _MethodTestVisitor extends RecursiveAstVisitor<void> {
-  static const _testMethodNameList = <String>{
+  final _testMethodNameList = <String>{
     'test',
     'testWidgets',
   };
@@ -34,7 +35,9 @@ class _MethodTestVisitor extends RecursiveAstVisitor<void> {
 
   final Iterable<String> _includeAssertions;
 
-  _MethodTestVisitor(this._includeAssertions);
+  _MethodTestVisitor(this._includeAssertions, Iterable<String> includeMethods) {
+    _testMethodNameList.addAll(includeMethods);
+  }
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
@@ -73,10 +76,8 @@ class _MethodAssertionVisitor extends RecursiveAstVisitor<void> {
     'expectLater',
   };
 
-  final Iterable<String> _includeAssertions;
-
-  _MethodAssertionVisitor(this._includeAssertions) {
-    _assertionMethodNameList.addAll(_includeAssertions);
+  _MethodAssertionVisitor(Iterable<String> includeAssertions) {
+    _assertionMethodNameList.addAll(includeAssertions);
   }
 
   bool hasContainedAssertion = false;

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/examples/custom_methods_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/examples/custom_methods_example.dart
@@ -1,0 +1,9 @@
+void main() {
+  print('Hello');
+
+  customTest(null, () => 1 == 1); // LINT
+
+  otherTestMethod(null, () => 1 == 1); // LINT
+
+  excludedTestMethod(null, () => 1 == 1);
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/missing_test_assertion_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/missing_test_assertion_test.dart
@@ -10,6 +10,8 @@ const _incorrectExamplePath =
     'missing_test_assertion/examples/incorrect_example.dart';
 const _customAssertionsExamplePath =
     'missing_test_assertion/examples/custom_assertions_example.dart';
+const _customMethodsExamplePath =
+    'missing_test_assertion/examples/custom_methods_example.dart';
 
 void main() {
   group('MissingTestAssertion', () {
@@ -31,7 +33,7 @@ void main() {
       RuleTestHelper.verifyNoIssues(issues);
     });
 
-    test('with custom config reports no issues', () async {
+    test('with custom assertions config reports no issues', () async {
       final unit =
           await RuleTestHelper.resolveFromFile(_customAssertionsExamplePath);
       final config = {
@@ -66,6 +68,32 @@ void main() {
         ],
         messages: [
           'Missing test assertion.',
+          'Missing test assertion.',
+          'Missing test assertion.',
+        ],
+      );
+    });
+
+    test('with custom methods config reports about found issues', () async {
+      final unit =
+          await RuleTestHelper.resolveFromFile(_customMethodsExamplePath);
+      final config = {
+        'include-methods': [
+          'customTest',
+          'otherTestMethod',
+        ],
+      };
+      final issues = MissingTestAssertionRule(config).check(unit);
+
+      RuleTestHelper.verifyIssues(
+        issues: issues,
+        startLines: [4, 6],
+        startColumns: [3, 3],
+        locationTexts: [
+          'customTest(null, () => 1 == 1)',
+          'otherTestMethod(null, () => 1 == 1)',
+        ],
+        messages: [
           'Missing test assertion.',
           'Missing test assertion.',
         ],

--- a/website/docs/rules/common/missing-test-assertion.mdx
+++ b/website/docs/rules/common/missing-test-assertion.mdx
@@ -1,10 +1,14 @@
 import RuleDetails from '@site/src/components/RuleDetails';
 
-<RuleDetails version="4.21.0" severity="style" />
+<RuleDetails version="4.21.0" severity="warning" />
 
 Warns that there is no assertion in the test.
 
 Use `include-assertions` configuration, if you want to include specific assertions.
+Defaults to Dart default assertions including expect, expectLater and all expectAsync variants.
+
+Use `include-methods` configuration, if you want the linter to check particular test methods for missing assertions.
+Defaults to `test` and `testWidgets` methods.
 
 ### ⚙️ Config example {#config-example}
 
@@ -16,6 +20,8 @@ dart_code_metrics:
     - missing-test-assertion:
         include-assertions:
           - verify
+        include-methods:
+          - customTest
 ```
 
 ### Example {#example}


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

Completes issue #1019, PR #1023 

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

This PR aims at completing issue #1019 and PR #1023 about the new missing_test_assertion rule, by adding the possibility to enter additional test methods names to be checked in addition to the default `test` and `testWidgets` methods.

This new config might be useful when using dedicated test methods that potentially come from other packages, or just test wrappers written by the developers. E.g. we could create a base `companyXTest()` method that acts as a wrapper around test/testWidgets and sets some basic configuration for our company tests.  

As a side note, I also changed the severity from "style" to "warning" in the doc, seems more appropriate.

### Is there anything you'd like reviewers to focus on?

Config name, I can change it if "include-methods" is not clear enough.