### PR TITLE
feat: add method call chains support on ban-name ident

### DIFF
--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/ban_name_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/ban_name_rule.dart
@@ -33,7 +33,24 @@ class BanNameRule extends CommonRule {
 
     source.unit.visitChildren(visitor);
 
-    return visitor.nodes
+    final filteredNodeList = visitor.nodes.where((node) {
+      if (node.endNode != null) {
+        final inlineNode = source.content
+            .substring(
+              node.node.offset,
+              node.endNode!.end,
+            )
+            .replaceAll('\n', '');
+
+        if (!inlineNode.contains(node.fullName)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    return filteredNodeList
         .map(
           (node) => createIssue(
             rule: this,

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/ban_name_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/ban_name_rule.dart
@@ -37,7 +37,11 @@ class BanNameRule extends CommonRule {
         .map(
           (node) => createIssue(
             rule: this,
-            location: nodeLocation(node: node.node, source: source),
+            location: nodeLocation(
+              node: node.node,
+              source: source,
+              endNode: node.endNode,
+            ),
             message: node.message,
           ),
         )

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/visitor.dart
@@ -53,22 +53,24 @@ class _Visitor extends GeneralizingAstVisitor<void> {
       _nodeBreadcrumb.addAll({name: node});
     }
 
-    final breadcrumbString = _nodeBreadcrumb.keys.join('.');
-    if (_entryMap.containsKey(breadcrumbString)) {
+    if (_entryMap.containsKey(name)) {
       _nodes.add(_NodeInfo(
-        _nodeBreadcrumb.values.first,
-        message:
-            '${_entryMap[breadcrumbString]!.description} ($breadcrumbString is banned)',
-        endNode: _nodeBreadcrumb.values.last,
+        node,
+        fullName: name,
+        message: '${_entryMap[name]!.description} ($name is banned)',
       ));
 
       return;
     }
 
-    if (_entryMap.containsKey(name)) {
+    final breadcrumbString = _nodeBreadcrumb.keys.join('.');
+    if (_entryMap.containsKey(breadcrumbString)) {
       _nodes.add(_NodeInfo(
-        node,
-        message: '${_entryMap[name]!.description} ($name is banned)',
+        _nodeBreadcrumb.values.first,
+        fullName: breadcrumbString,
+        message:
+            '${_entryMap[breadcrumbString]!.description} ($breadcrumbString is banned)',
+        endNode: _nodeBreadcrumb.values.last,
       ));
     }
   }
@@ -76,8 +78,14 @@ class _Visitor extends GeneralizingAstVisitor<void> {
 
 class _NodeInfo {
   final AstNode node;
+  final String fullName;
   final String message;
   final AstNode? endNode;
 
-  _NodeInfo(this.node, {required this.message, this.endNode});
+  _NodeInfo(
+    this.node, {
+    required this.fullName,
+    required this.message,
+    this.endNode,
+  });
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/ban_name/visitor.dart
@@ -3,9 +3,9 @@ part of 'ban_name_rule.dart';
 class _Visitor extends GeneralizingAstVisitor<void> {
   final Map<String, _BanNameConfigEntry> _entryMap;
 
-  final _nodes = <_NodeWithMessage>[];
+  final _nodes = <_NodeInfo>[];
 
-  Iterable<_NodeWithMessage> get nodes => _nodes;
+  Iterable<_NodeInfo> get nodes => _nodes;
 
   final _nodeBreadcrumb = <String, AstNode>{};
 
@@ -43,33 +43,41 @@ class _Visitor extends GeneralizingAstVisitor<void> {
   void _visitIdent(AstNode node, String name) {
     final prevNode =
         _nodeBreadcrumb.isNotEmpty ? _nodeBreadcrumb.values.last : null;
-    if (prevNode == null || node.offset == (prevNode.end + 1)) {
+    if (node.offset - 1 == prevNode?.end) {
       _nodeBreadcrumb.addAll({name: node});
     } else {
       _nodeBreadcrumb.clear();
     }
 
+    if (_nodeBreadcrumb.isEmpty) {
+      _nodeBreadcrumb.addAll({name: node});
+    }
+
     final breadcrumbString = _nodeBreadcrumb.keys.join('.');
     if (_entryMap.containsKey(breadcrumbString)) {
-      _nodes.add(_NodeWithMessage(
+      _nodes.add(_NodeInfo(
         _nodeBreadcrumb.values.first,
-        '${_entryMap[breadcrumbString]!.description} ($breadcrumbString is banned)',
+        message:
+            '${_entryMap[breadcrumbString]!.description} ($breadcrumbString is banned)',
+        endNode: _nodeBreadcrumb.values.last,
       ));
+
       return;
     }
 
     if (_entryMap.containsKey(name)) {
-      _nodes.add(_NodeWithMessage(
+      _nodes.add(_NodeInfo(
         node,
-        '${_entryMap[name]!.description} ($name is banned)',
+        message: '${_entryMap[name]!.description} ($name is banned)',
       ));
     }
   }
 }
 
-class _NodeWithMessage {
+class _NodeInfo {
   final AstNode node;
   final String message;
+  final AstNode? endNode;
 
-  _NodeWithMessage(this.node, this.message);
+  _NodeInfo(this.node, {required this.message, this.endNode});
 }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/ban_name_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/ban_name_rule_test.dart
@@ -27,13 +27,17 @@ void main() {
           {'ident': 'showDialog', 'description': 'Please use myShowDialog'},
           {'ident': 'strangeName', 'description': 'The name is too strange'},
           {'ident': 'AnotherStrangeName', 'description': 'Oops'},
+          {
+            'ident': 'StrangeClass.someMethod',
+            'description': 'Please use NonStrangeClass.someMethod instead',
+          },
         ],
       }).check(unit);
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [6, 7, 9, 12, 15, 16],
-        startColumns: [3, 12, 7, 1, 1, 12],
+        startLines: [7, 8, 10, 13, 16, 17, 20],
+        startColumns: [3, 12, 7, 1, 1, 12, 1],
         locationTexts: [
           'showDialog',
           'showDialog',
@@ -43,6 +47,7 @@ void main() {
               '  late var strangeName; // LINT\n'
               '}',
           'strangeName',
+          'StrangeClass',
         ],
         messages: [
           'Please use myShowDialog (showDialog is banned)',
@@ -51,6 +56,7 @@ void main() {
           'The name is too strange (strangeName is banned)',
           'Oops (AnotherStrangeName is banned)',
           'The name is too strange (strangeName is banned)',
+          'Please use NonStrangeClass.someMethod instead (StrangeClass.someMethod is banned)',
         ],
       );
     });

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/ban_name_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/ban_name_rule_test.dart
@@ -31,13 +31,17 @@ void main() {
             'ident': 'StrangeClass.someMethod',
             'description': 'Please use NonStrangeClass.someMethod instead',
           },
+          {
+            'ident': 'DateTime.now',
+            'description': 'Please use clock.now instead',
+          },
         ],
       }).check(unit);
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [7, 8, 10, 13, 16, 17, 20],
-        startColumns: [3, 12, 7, 1, 1, 12, 1],
+        startLines: [7, 8, 10, 13, 16, 17, 20, 23, 24, 26],
+        startColumns: [3, 12, 7, 1, 1, 12, 1, 1, 1, 28],
         locationTexts: [
           'showDialog',
           'showDialog',
@@ -47,7 +51,10 @@ void main() {
               '  late var strangeName; // LINT\n'
               '}',
           'strangeName',
-          'StrangeClass',
+          'StrangeClass.someMethod();',
+          'DateTime.now();',
+          'DateTime.now()',
+          'DateTime.now',
         ],
         messages: [
           'Please use myShowDialog (showDialog is banned)',
@@ -57,6 +64,9 @@ void main() {
           'Oops (AnotherStrangeName is banned)',
           'The name is too strange (strangeName is banned)',
           'Please use NonStrangeClass.someMethod instead (StrangeClass.someMethod is banned)',
+          'Please use clock.now instead (DateTime.now is banned)',
+          'Please use clock.now instead (DateTime.now is banned)',
+          'Please use clock.now instead (DateTime.now is banned)',
         ],
       );
     });

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/examples/classes.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/examples/classes.dart
@@ -1,0 +1,7 @@
+class StrangeClass {
+  void someMethod();
+}
+
+class NonStrangeClass {
+  void someMethod();
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/examples/example.dart
@@ -1,5 +1,6 @@
 import 'dialog.dart';
 import 'dialog.dart' as material;
+import 'classes.dart';
 
 void func() {
   myShowDialog('some_arguments', 'another_argument');
@@ -15,3 +16,6 @@ void strangeName() {} // LINT
 class AnotherStrangeName {
   late var strangeName; // LINT
 }
+
+StrangeClass.someMethod(); // LINT
+NonStrangeClass.someMethod();

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/examples/example.dart
@@ -19,3 +19,10 @@ class AnotherStrangeName {
 
 StrangeClass.someMethod(); // LINT
 NonStrangeClass.someMethod();
+
+DateTime.now(); // LINT
+DateTime.now().day; // LINT
+class DateTimeTest {
+  final currentTimestamp = DateTime.now(); // LINT
+}
+DateTime currentTimestamp = DateTime('01.01.1959');

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/ban_name/examples/example.dart
@@ -25,4 +25,4 @@ DateTime.now().day; // LINT
 class DateTimeTest {
   final currentTimestamp = DateTime.now(); // LINT
 }
-DateTime currentTimestamp = DateTime('01.01.1959');
+DateTime now = DateTime(2022);

--- a/website/docs/rules/common/ban-name.mdx
+++ b/website/docs/rules/common/ban-name.mdx
@@ -9,6 +9,7 @@ Example: When you add some extra functionalities to built-in Flutter functions (
 :::caution
 
 When trying to ban some methods in your package, it also triggers on imported from an external package code.
+But you can specify the name to ban (ex: 'Counter.value' instead of 'value').
 
 :::
 
@@ -30,12 +31,15 @@ void strangeName() {} // LINT
 class AnotherStrangeName {
   late var strangeName; // LINT
 }
+
+StrangeClass.someMethod(); // LINT
 ```
 
 **✅ Good:**
 
 ```dart
 myShowDialog();
+NonStrangeClass.someMethod();
 ```
 
 ### ⚙️ Config example {#config-example}
@@ -53,4 +57,6 @@ dart_code_metrics:
           description: The name is too strange
         - ident: AnotherStrangeName
           description: Oops
+        - ident: StrangeClass.someMethod
+          description: Please use a NonStrangeClass.someMethod instead
 ```

--- a/website/docs/rules/common/ban-name.mdx
+++ b/website/docs/rules/common/ban-name.mdx
@@ -9,7 +9,7 @@ Example: When you add some extra functionalities to built-in Flutter functions (
 :::caution
 
 When trying to ban some methods in your package, it also triggers on imported from an external package code.
-But you can specify the name to ban (ex: 'Counter.value' instead of 'value').
+But you can specify the name to ban (ex: 'DateTime.now' instead of 'now').
 
 :::
 
@@ -33,6 +33,14 @@ class AnotherStrangeName {
 }
 
 StrangeClass.someMethod(); // LINT
+NonStrangeClass.someMethod();
+
+DateTime.now(); // LINT
+DateTime.now().day; // LINT
+class DateTimeTest {
+  final currentTimestamp = DateTime.now(); // LINT
+}
+DateTime currentTimestamp = DateTime('01.01.1959');
 ```
 
 **✅ Good:**
@@ -40,6 +48,11 @@ StrangeClass.someMethod(); // LINT
 ```dart
 myShowDialog();
 NonStrangeClass.someMethod();
+clock.now();
+clock.now().day;
+class DateTimeTest {
+  final currentTimestamp = clock.now();
+}
 ```
 
 ### ⚙️ Config example {#config-example}
@@ -59,4 +72,6 @@ dart_code_metrics:
           description: Oops
         - ident: StrangeClass.someMethod
           description: Please use a NonStrangeClass.someMethod instead
+        - ident: DateTime.now
+          description: Please use a clock.now instead
 ```


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [x] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

This PR extends the ban-name rule abilities to recursive search in method call chains. (ex: `DateTime.now` or `StrangeClass.someField.subField` etc.)
Ban-name rule's visitor will have a breadcrumb now and will compare breadcrumb node names with the rule ident.

Resolves the #927 

> **IMPORTANT:**
> Tests passes, CLI works as expected. But the IDE does not highlight method call chains. I'm trying to figure out what's wrong
>
> **UPD:**
> **Progress is [here](https://github.com/dart-lang/sdk/issues/50209)**
