### PR TITLE
fix(avoid-passing-async-when-sync-expected):   FutureOr Functions are…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.21.2
+
+* fix(avoid-passing-async-when-sync-expected): FutureOr Functions are interpreted as synchronous functions
+
 ## 4.21.1
 
 * fix: stop plugin flickering after migration to new api.

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/visitor.dart
@@ -29,7 +29,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
       final parameterType = argument.staticParameterElement?.type;
       if (argumentType is FunctionType && parameterType is FunctionType) {
         if (argumentType.returnType.isDartAsyncFuture &&
-            !parameterType.returnType.isDartAsyncFuture) {
+            (!parameterType.returnType.isDartAsyncFuture &&
+                !parameterType.returnType.isDartAsyncFutureOr)) {
           _invalidArguments.add(argument);
         }
       }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/examples/example.dart
@@ -88,4 +88,10 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
     );
   }
+
+  Future<String> doSomeGetRequest() => Future.value('');
+
+  Future<String> doAnotherGetRequest(String input) => Future.value('');
+
+  Future<String> main() => doSomeGetRequest().then(doAnotherGetRequest);
 }


### PR DESCRIPTION
… interpreted as synchronous functions

<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->
- https://github.com/dart-code-checker/dart-code-metrics/issues/1033
<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

- Add case in example
- I change the condition to check if parameter is async or not

### Is there anything you'd like reviewers to focus on?

No