### PR TITLE
chore: restrict `analyzer` for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * feat: add static code diagnostic [`avoid-cascade-after-if-null`](https://dartcodemetrics.dev/docs/rules/common/avoid-cascade-after-if-null).
 * feat: **Breaking change** handle widget members order separately in [`member-ordering`](https://dartcodemetrics.dev/docs/rules/common/member-ordering).
 * feat: support dynamic method names for [`member-ordering`](https://dartcodemetrics.dev/docs/rules/common/member-ordering).
+* chore: restrict `analyzer` version to `>=4.4.0 <5.2.0`.
+* chore: set min `coverage` version to `^1.6.1`.
+* chore: set min `lints` version to `^2.0.1`.
+* chore: set min `test` version to `^1.21.6`.
 
 ## 4.21.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=5.1.0 <5.2.0"
+  analyzer: ">=4.4.0 <5.2.0" # >=4.5.0 not compatible with pigeon >=5.0.0 not compatible with test
   analyzer_plugin: ">=0.11.0 <0.12.0"
   ansicolor: ^2.0.1
   args: ^2.0.0
@@ -21,18 +21,18 @@ dependencies:
   html: ">=0.15.0 <1.0.0"
   meta: ^1.7.0
   path: ^1.8.0
-  platform: ^3.1.0 # overridden for lowest versions compatibility
+  platform: ^3.1.0
   pub_updater: ^0.2.2
   source_span: ^1.8.0
   xml: ">=5.3.0 <7.0.0"
   yaml: ^3.1.0
 
 dev_dependencies:
-  coverage: ^1.0.2
+  coverage: ^1.6.1
   intl: ^0.17.0
-  lints: ^2.0.0
+  lints: ^2.0.1
   mocktail: ^0.3.0
-  test: ^1.21.0
+  test: ^1.21.6
 
   # internal package, used only in tests data
   test_lints:


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [x] Other, please explain:
    Downgrade minimum version for `analyzer` to be able to use `pigeon` and `mocktail` in my project.

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

I downgrade `analyzer` and upgrade `dev_dependencies`

### Is there anything you'd like reviewers to focus on?

No
