### PR TITLE
fix: check `of` constructor exist for `prefer-iterable-of`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * feat: add static code diagnostic [`avoid-cascade-after-if-null`](https://dartcodemetrics.dev/docs/rules/common/avoid-cascade-after-if-null).
 * feat: **Breaking change** handle widget members order separately in [`member-ordering`](https://dartcodemetrics.dev/docs/rules/common/member-ordering).
 * feat: support dynamic method names for [`member-ordering`](https://dartcodemetrics.dev/docs/rules/common/member-ordering).
+* fix: check `of` constructor exist for [`prefer-iterable-of`](https://dartcodemetrics.dev/docs/rules/common/prefer-iterable-of)
 
 ## 4.21.2
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_iterable_of/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_iterable_of/visitor.dart
@@ -10,12 +10,12 @@ class _Visitor extends RecursiveAstVisitor<void> {
     super.visitInstanceCreationExpression(node);
 
     if (isIterableOrSubclass(node.staticType) &&
-        node.constructorName.name?.name == 'from') {
+        node.constructorName.name?.name == 'from' &&
+        _hasConstructorOf(node.staticType)) {
       final arg = node.argumentList.arguments.first;
 
       final argumentType = _getType(arg.staticType);
       final castedType = _getType(node.staticType);
-
       if (argumentType != null &&
           !argumentType.isDartCoreObject &&
           !argumentType.isDynamic &&
@@ -23,6 +23,14 @@ class _Visitor extends RecursiveAstVisitor<void> {
         _expressions.add(node);
       }
     }
+  }
+
+  bool _hasConstructorOf(DartType? type) {
+    if (type is InterfaceType) {
+      return type.constructors.any((element) => element.name == 'of');
+    }
+
+    return false;
   }
 
   DartType? _getType(DartType? type) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   analyzer_plugin: ">=0.11.0 <0.12.0"
   ansicolor: ^2.0.1
   args: ^2.0.0
-  collection: ^1.15.0
+  collection: ^1.16.0
   crypto: ^3.0.0
   file: ^6.0.0
   glob: ^2.0.1

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_iterable_of/examples/queue_list_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_iterable_of/examples/queue_list_example.dart
@@ -1,0 +1,19 @@
+import 'package:collection/collection.dart';
+
+void main() {
+  const queue = QueueList.of([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+  final copy = QueueList<int>.from(queue);
+  final numQueue = QueueList<num>.from(queue);
+
+  final intQueue = QueueList<int>.from(numQueue);
+
+  final unspecifedQueue = QueueList.from(queue);
+
+  final dynamicQueue = QueueList<dynamic>.from([1, 2, 3]);
+  final copy = QueueList<int>.from(dynamicQueue);
+  final dynamicCopy = QueueList.from(dynamicQueue);
+
+  final objectQueue = QueueList<Object>.from([1, 2, 3]);
+  final copy = QueueList<int>.from(objectQueue);
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_iterable_of/prefer_iterable_of_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_iterable_of/prefer_iterable_of_rule_test.dart
@@ -14,6 +14,8 @@ const _linkedHashSetExamplePath =
 const _listQueueExamplePath =
     'prefer_iterable_of/examples/list_queue_example.dart';
 const _queueExamplePath = 'prefer_iterable_of/examples/queue_example.dart';
+const _queueListExamplePath =
+    'prefer_iterable_of/examples/queue_list_example.dart';
 const _splayTreeSetExamplePath =
     'prefer_iterable_of/examples/splay_tree_set_example.dart';
 
@@ -246,6 +248,21 @@ void main() {
           "Replace with 'of'.",
           "Replace with 'of'.",
         ],
+      );
+    });
+
+    test('reports about found issues for queue list', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_queueListExamplePath);
+      final issues = PreferIterableOfRule().check(unit);
+
+      RuleTestHelper.verifyIssues(
+        issues: issues,
+        startLines: [],
+        startColumns: [],
+        locationTexts: [],
+        messages: [],
+        replacements: [],
+        replacementComments: [],
       );
     });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->
- https://github.com/dart-code-checker/dart-code-metrics/issues/1046
<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

I check if the type contain a `of` constructor.

### Is there anything you'd like reviewers to focus on?

No