### PR TITLE
fix: add fail assertion as a valid method to missing_test_assertion rule

### DIFF
--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/visitor.dart
@@ -74,6 +74,7 @@ class _MethodAssertionVisitor extends RecursiveAstVisitor<void> {
     'expectAsyncUntil5',
     'expectAsyncUntil6',
     'expectLater',
+    'fail',
   };
 
   _MethodAssertionVisitor(Iterable<String> includeAssertions) {

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/examples/correct_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/missing_test_assertion/examples/correct_example.dart
@@ -74,5 +74,9 @@ void main() {
     expectAsyncUntil6((p0, p1, p2, p3, p4, p5) {}, () => true);
   });
 
+  test('with fail', () {
+    fail('some failure reason');
+  });
+
   test(null, () => expect(1, 1));
 }

--- a/website/docs/rules/common/missing-test-assertion.mdx
+++ b/website/docs/rules/common/missing-test-assertion.mdx
@@ -5,7 +5,7 @@ import RuleDetails from '@site/src/components/RuleDetails';
 Warns that there is no assertion in the test.
 
 Use `include-assertions` configuration, if you want to include specific assertions.
-Defaults to Dart default assertions including expect, expectLater and all expectAsync variants.
+Defaults to Dart default assertions including expect, expectLater, all expectAsync variants and fail.
 
 Use `include-methods` configuration, if you want the linter to check particular test methods for missing assertions.
 Defaults to `test` and `testWidgets` methods.


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] New rule
- [X] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

Add `fail` method as a valid test assertion for missing_test_assertion as it is a valid way to make an assertion in a test.

### Is there anything you'd like reviewers to focus on?
