### PR TITLE
fix: support function expression invocations for prefer-moving-to-variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* fix: support function expression invocations for [`prefer-moving-to-variable`](https://dartcodemetrics.dev/docs/rules/common/prefer-moving-to-variable).
+
 ## 5.2.1
 
 * fix: avoid null check exception in the analyzer.

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
@@ -64,7 +64,7 @@ class _BlockVisitor extends RecursiveAstVisitor<void> {
   }
 
   bool _checkForDuplicates(AstNode node, Expression? target) {
-    final access = node.toString();
+    final access = _extractAccess(node);
     final visitedInvocation = _visitedInvocations[access];
     final isDuplicate =
         visitedInvocation != null && _isDuplicate(visitedInvocation, node);
@@ -84,6 +84,18 @@ class _BlockVisitor extends RecursiveAstVisitor<void> {
     _visitAllTargets(target);
 
     return false;
+  }
+
+  String _extractAccess(AstNode node) {
+    final parent = node.parent;
+    if (parent is FunctionExpressionInvocation) {
+      final typeArguments = parent.typeArguments;
+      if (typeArguments != null && typeArguments.arguments.isNotEmpty) {
+        return parent.toString();
+      }
+    }
+
+    return node.toString();
   }
 
   bool _isDuplicate(AstNode visitedInvocation, AstNode node) {

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/examples/generics_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/examples/generics_example.dart
@@ -1,0 +1,14 @@
+void main() {
+  final a = GetIt.instance<Object>();
+  final b = GetIt.instance<String>();
+}
+
+class GetIt {
+  static final _instance = GetIt();
+
+  static GetIt get instance => _instance;
+
+  T get<T extends Object>() => 'str' as T;
+
+  T call<T extends Object>() => return get<T>;
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/prefer_moving_to_variable_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/prefer_moving_to_variable_rule_test.dart
@@ -13,6 +13,8 @@ const _scopeExamplePath =
     'prefer_moving_to_variable/examples/scope_example.dart';
 const _cascadeExamplePath =
     'prefer_moving_to_variable/examples/cascade_example.dart';
+const _genericsExamplePath =
+    'prefer_moving_to_variable/examples/generics_example.dart';
 
 void main() {
   group('PreferMovingToVariableRule', () {
@@ -208,6 +210,13 @@ void main() {
 
     test('reports no issues for cascade', () async {
       final unit = await RuleTestHelper.resolveFromFile(_cascadeExamplePath);
+      final issues = PreferMovingToVariableRule().check(unit);
+
+      RuleTestHelper.verifyNoIssues(issues);
+    });
+
+    test('reports no issues for generics', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_genericsExamplePath);
       final issues = PreferMovingToVariableRule().check(unit);
 
       RuleTestHelper.verifyNoIssues(issues);


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

#1101 