### PR TITLE
fix: ignore doc comments for prefer-commenting-analyzer-ignores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * feat: add `strict` config option to [`avoid-collection-methods-with-unrelated-types`](https://dartcodemetrics.dev/docs/rules/common/avoid-collection-methods-with-unrelated-types).
 * fix: support function expression invocations for [`prefer-moving-to-variable`](https://dartcodemetrics.dev/docs/rules/common/prefer-moving-to-variable).
 * feat: support ignoring regular comments for [`format-comment`](https://dartcodemetrics.dev/docs/rules/common/format-comment).
+* fix: ignore doc comments for [`prefer-commenting-analyzer-ignores`](https://dartcodemetrics.dev/docs/rules/common/prefer-commenting-analyzer-ignores).
 
 ## 5.2.1
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_commenting_analyzer_ignores/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_commenting_analyzer_ignores/visitor.dart
@@ -54,7 +54,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
     final previous = node.previous;
 
     return previous == null ||
-        (previous.type != TokenType.SINGLE_LINE_COMMENT ||
+        ((previous.type != TokenType.SINGLE_LINE_COMMENT ||
+                previous.toString().startsWith('///')) ||
             _lineInfo.getLocation(node.offset).lineNumber - 1 !=
                 _lineInfo.getLocation(previous.offset).lineNumber);
   }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_commenting_analyzer_ignores/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_commenting_analyzer_ignores/examples/example.dart
@@ -18,4 +18,8 @@ void main() {
 
   // ignore: avoid-non-null-assertion, checked for non-null
   final hashMap = HashMap();
+
+  /// documentation comment
+  // ignore: avoid-non-null-assertion
+  final value = 1; // LINT
 }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_commenting_analyzer_ignores/prefer_commenting_analyzer_ignores_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_commenting_analyzer_ignores/prefer_commenting_analyzer_ignores_rule_test.dart
@@ -25,13 +25,15 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [3, 6],
-        startColumns: [3, 3],
+        startLines: [3, 6, 23],
+        startColumns: [3, 3, 3],
         locationTexts: [
           '// ignore: deprecated_member_use',
           '// ignore: deprecated_member_use, long-method',
+          '// ignore: avoid-non-null-assertion',
         ],
         messages: [
+          'Prefer commenting analyzer ignores.',
           'Prefer commenting analyzer ignores.',
           'Prefer commenting analyzer ignores.',
         ],


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

#1114 
