### PR TITLE
fix: use-setstate-synchronously edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * feat: support ignoring nesting for [`prefer-conditional-expressions`](https://dartcodemetrics.dev/docs/rules/common/prefer-conditional-expressions).
 * fix: ignore Providers for ['avoid-returning-widgets'](https://dartcodemetrics.dev/docs/rules/common/avoid-returning-widgets).
 * feat: add [`use-setstate-synchronously`](https://dartcodemetrics.dev/docs/rules/flutter/use-setstate-synchronously).
+* fix: correctly invalidate edge cases for [`use-setstate-synchronously`](https://dartcodemetrics.dev/docs/rules/flutter/use-setstate-synchronously)
 
 ## 5.3.0
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/visitor.dart
@@ -64,10 +64,9 @@ class _AsyncSetStateVisitor extends RecursiveAstVisitor<void> {
     }
 
     node.condition.visitChildren(this);
-    final oldMounted = mounted;
     final newMounted = _extractMountedCheck(node.condition);
-
     mounted = newMounted.or(mounted);
+
     final beforeThen = mounted;
     node.thenStatement.visitChildren(this);
     final afterThen = mounted;
@@ -86,8 +85,6 @@ class _AsyncSetStateVisitor extends RecursiveAstVisitor<void> {
       mounted = beforeThen != afterThen
           ? afterThen
           : _extractMountedCheck(node.condition, permitAnd: false);
-    } else {
-      mounted = oldMounted;
     }
   }
 
@@ -103,7 +100,9 @@ class _AsyncSetStateVisitor extends RecursiveAstVisitor<void> {
     mounted = newMounted.or(mounted);
     node.body.visitChildren(this);
 
-    mounted = _blockDiverges(node.body) ? _tryInvert(newMounted) : oldMounted;
+    if (_blockDiverges(node.body)) {
+      mounted = _tryInvert(newMounted).or(oldMounted);
+    }
   }
 
   @override

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/examples/example.dart
@@ -1,5 +1,23 @@
 class _FooState extends State<StatefulWidget> {
-  void fetchData() async {
+  Widget build(context) {
+    return FooWidget(
+      onChange: (value) async {
+        setState(() {});
+        await fetchData();
+        setState(() {}); // LINT
+
+        if (mounted) setState(() {});
+      },
+    );
+  }
+
+  void customConfig() async {
+    await fetch();
+    foobar(); // LINT
+    this.foobar(); // LINT
+  }
+
+  void pathologicalCases() async {
     setState(() {});
 
     await fetch();
@@ -62,24 +80,21 @@ class _FooState extends State<StatefulWidget> {
       return;
     }
     setState(() {}); // LINT
-  }
 
-  Widget build(context) {
-    return FooWidget(
-      onChange: (value) async {
-        setState(() {});
-        await fetchData();
-        setState(() {}); // LINT
+    while (!mounted || foo || foo) {
+      return;
+    }
+    setState(() {});
 
-        if (mounted) setState(() {});
-      },
-    );
-  }
+    while (mounted) {
+      await fetch();
+    }
+    setState(() {}); // LINT
 
-  void customConfig() async {
-    await fetch();
-    foobar(); // LINT
-    this.foobar(); // LINT
+    if (mounted) {
+      await fetch();
+    }
+    setState(() {}); // LINT
   }
 }
 

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/use_setstate_synchronously_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/use_setstate_synchronously_rule_test.dart
@@ -26,9 +26,11 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [6, 11, 18, 33, 48, 52, 58, 64, 72],
-        startColumns: [10, 7, 7, 5, 7, 5, 5, 5, 9],
+        startLines: [7, 24, 29, 36, 51, 66, 70, 76, 82, 92, 97],
+        startColumns: [9, 10, 7, 7, 5, 7, 5, 5, 5, 5, 5],
         locationTexts: [
+          'setState',
+          'setState',
           'setState',
           'setState',
           'setState',
@@ -40,6 +42,8 @@ void main() {
           'setState',
         ],
         messages: [
+          "Avoid calling 'setState' past an await point without checking if the widget is mounted.",
+          "Avoid calling 'setState' past an await point without checking if the widget is mounted.",
           "Avoid calling 'setState' past an await point without checking if the widget is mounted.",
           "Avoid calling 'setState' past an await point without checking if the widget is mounted.",
           "Avoid calling 'setState' past an await point without checking if the widget is mounted.",
@@ -77,12 +81,9 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [81, 82],
+        startLines: [16, 17],
         startColumns: [5, 10],
-        locationTexts: [
-          'foobar',
-          'foobar',
-        ],
+        locationTexts: ['foobar', 'foobar'],
         messages: [
           "Avoid calling 'foobar' past an await point without checking if the widget is mounted.",
           "Avoid calling 'foobar' past an await point without checking if the widget is mounted.",

--- a/website/docs/rules/flutter/use-setstate-synchronously.mdx
+++ b/website/docs/rules/flutter/use-setstate-synchronously.mdx
@@ -1,6 +1,6 @@
 import RuleDetails from '@site/src/components/RuleDetails';
 
-<RuleDetails version="UNRELEASED" severity="warning" hasConfig />
+<RuleDetails version="5.4.0" severity="warning" hasConfig />
 
 Warns when [`setState`] is called past an *await point* (also known as asynchronous gap) within a subclass of State.
 


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

<!--
    Please ensure your pull request is ready:

    - Include tests for this change
    - Update documentation for this change
-->

### What changes did you make? (Give an overview)

Fixes mountedness invalidation in this case:

```dart
if (mounted) { // or 'while'
  await fetch();
}
setState(() {}); // LINT
```

### Is there anything you'd like reviewers to focus on?
