### PR TITLE
fix: list-all-equatable-fields should be typed common

### DIFF
--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/list_all_equatable_fields/list_all_equatable_fields_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/list_all_equatable_fields/list_all_equatable_fields_rule.dart
@@ -11,12 +11,12 @@ import '../../../lint_utils.dart';
 import '../../../models/internal_resolved_unit_result.dart';
 import '../../../models/issue.dart';
 import '../../../models/severity.dart';
-import '../../models/flutter_rule.dart';
+import '../../models/common_rule.dart';
 import '../../rule_utils.dart';
 
 part 'visitor.dart';
 
-class ListAllEquatableFieldsRule extends FlutterRule {
+class ListAllEquatableFieldsRule extends CommonRule {
   static const ruleId = 'list-all-equatable-fields';
 
   ListAllEquatableFieldsRule([

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/list_all_equatable_fields/list_all_equatable_fields_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/list_all_equatable_fields/list_all_equatable_fields_rule_test.dart
@@ -1,4 +1,6 @@
 import 'package:dart_code_metrics/src/analyzers/lint_analyzer/models/severity.dart';
+import 'package:dart_code_metrics/src/analyzers/lint_analyzer/rules/models/rule_type.dart';
+import 'package:dart_code_metrics/src/analyzers/lint_analyzer/rules/rule_utils.dart';
 import 'package:dart_code_metrics/src/analyzers/lint_analyzer/rules/rules_list/list_all_equatable_fields/list_all_equatable_fields_rule.dart';
 import 'package:test/test.dart';
 
@@ -8,6 +10,22 @@ const _examplePath = 'list_all_equatable_fields/examples/example.dart';
 
 void main() {
   group('ListAllEquatableFieldsRule', () {
+    test('is of type common', () {
+      expect(
+        ListAllEquatableFieldsRule().type,
+        equals(RuleType.common),
+      );
+    });
+
+    test('has expected documentation path', () {
+      final documentationUri = documentation(ListAllEquatableFieldsRule());
+
+      expect(
+        documentationUri.path,
+        equals('/docs/rules/common/list-all-equatable-fields'),
+      );
+    });
+
     test('initialization', () async {
       final unit = await RuleTestHelper.resolveFromFile(_examplePath);
       final issues = ListAllEquatableFieldsRule().check(unit);


### PR DESCRIPTION
- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

### What changes did you make? (Give an overview)

Initially `list-all-equatable-fields` was introduced as `FlutterRule` but properly documented as Common. Now when clicking on `Missing declared class fields: XYZ (Documentation)` inspection warning, the user ends up in wrong doc path:

<img width="833" alt="Screenshot 2023-01-07 at 02 15 42" src="https://user-images.githubusercontent.com/663351/211126110-920f351e-e18d-479b-b025-c5c6a990e85a.png">
