### PR TITLE
fix: ignore method invocations in a variable declaration for prefer-moving-to-variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * feat: exclude `.freezed.dart` files by default.
 * fix: handle try and switch statements for [`use-setstate-synchronously`](https://dartcodemetrics.dev/docs/rules/flutter/use-setstate-synchronously)
 * chore: restrict `analyzer` version to `>=5.1.0 <5.4.0`.
+* fix: ignore method invocations in a variable declaration for [`prefer-moving-to-variable`](https://dartcodemetrics.dev/docs/rules/common/prefer-moving-to-variable).
 
 ## 5.4.0
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
@@ -53,6 +53,7 @@ class _BlockVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitMethodInvocation(MethodInvocation node) {
     if (node.parent is CascadeExpression ||
+        node.parent is VariableDeclaration ||
         (node.staticType?.isVoid ?? false)) {
       return;
     }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/examples/assignment_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/examples/assignment_example.dart
@@ -1,0 +1,8 @@
+void main() {
+  final var1 = someFunction();
+  final var2 = someFunction();
+}
+
+String someFunction() {
+  return 'qwe';
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/prefer_moving_to_variable_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/prefer_moving_to_variable_rule_test.dart
@@ -15,6 +15,8 @@ const _cascadeExamplePath =
     'prefer_moving_to_variable/examples/cascade_example.dart';
 const _genericsExamplePath =
     'prefer_moving_to_variable/examples/generics_example.dart';
+const _assignmentExamplePath =
+    'prefer_moving_to_variable/examples/assignment_example.dart';
 
 void main() {
   group('PreferMovingToVariableRule', () {
@@ -210,6 +212,13 @@ void main() {
 
     test('reports no issues for cascade', () async {
       final unit = await RuleTestHelper.resolveFromFile(_cascadeExamplePath);
+      final issues = PreferMovingToVariableRule().check(unit);
+
+      RuleTestHelper.verifyNoIssues(issues);
+    });
+
+    test('reports no issues for assignments', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_assignmentExamplePath);
       final issues = PreferMovingToVariableRule().check(unit);
 
       RuleTestHelper.verifyNoIssues(issues);


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If this pull request is addressing an issue, please paste a link to the issue here.
-->

#1142 