### PR TITLE
fix: ignore enum constant arguments for no-magic-number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix: ignore enum constant arguments for [`no-magic-number`](https://dartcodemetrics.dev/docs/rules/common/no-magic-number).
 * fix: correctly handle prefixed enums and static instance fields for [`prefer-moving-to-variable`](https://dartcodemetrics.dev/docs/rules/common/prefer-moving-to-variable).
 * feat: add static code diagnostic [`prefer-provide-intl-description`](https://dartcodemetrics.dev/docs/rules/intl/prefer-provide-intl-description).
 * feat: exclude `.freezed.dart` files by default.

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/no_magic_number/no_magic_number_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/no_magic_number/no_magic_number_rule.dart
@@ -53,6 +53,7 @@ class NoMagicNumberRule extends CommonRule {
         .where(_isNotInsideConstConstructor)
         .where(_isNotInDateTime)
         .where(_isNotInsideIndexExpression)
+        .where(_isNotInsideEnumConstantArguments)
         .map((lit) => createIssue(
               rule: this,
               location: nodeLocation(node: lit, source: source),
@@ -79,6 +80,14 @@ class NoMagicNumberRule extends CommonRule {
                 'DateTime',
       ) ==
       null;
+
+  bool _isNotInsideEnumConstantArguments(Literal l) {
+    final node = l.thisOrAncestorMatching(
+      (ancestor) => ancestor is EnumConstantArguments,
+    );
+
+    return node == null;
+  }
 
   bool _isNotInsideCollectionLiteral(Literal l) => l.parent is! TypedLiteral;
 

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/no_magic_number/examples/enum_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/no_magic_number/examples/enum_example.dart
@@ -13,5 +13,5 @@ enum ExampleNamedMagicNumbers {
 
   final int value;
 
-  const ExampleMagicNumbers({required this.value});
+  const ExampleNamedMagicNumbers({required this.value});
 }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/no_magic_number/examples/enum_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/no_magic_number/examples/enum_example.dart
@@ -1,0 +1,17 @@
+enum ExampleMagicNumbers {
+  second(2),
+  third(3);
+
+  final int value;
+
+  const ExampleMagicNumbers(this.value);
+}
+
+enum ExampleNamedMagicNumbers {
+  second(value: 2),
+  third(value: 3);
+
+  final int value;
+
+  const ExampleMagicNumbers({required this.value});
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/no_magic_number/no_magic_number_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/no_magic_number/no_magic_number_rule_test.dart
@@ -9,6 +9,7 @@ const _incorrectExamplePath = 'no_magic_number/examples/incorrect_example.dart';
 const _exceptionsExamplePath =
     'no_magic_number/examples/exceptions_example.dart';
 const _arrayExamplePath = 'no_magic_number/examples/array_example.dart';
+const _enumExamplePath = 'no_magic_number/examples/enum_example.dart';
 
 void main() {
   group('NoMagicNumberRule', () {
@@ -37,6 +38,13 @@ void main() {
 
     test("doesn't report constants", () async {
       final unit = await RuleTestHelper.resolveFromFile(_examplePath);
+      final issues = NoMagicNumberRule().check(unit);
+
+      RuleTestHelper.verifyNoIssues(issues);
+    });
+
+    test("doesn't report enum arguments", () async {
+      final unit = await RuleTestHelper.resolveFromFile(_enumExamplePath);
       final issues = NoMagicNumberRule().check(unit);
 
       RuleTestHelper.verifyNoIssues(issues);


### PR DESCRIPTION
### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

### What changes did you make? (Give an overview)
Ignoring numbers in enum

<details>
  <summary>Example</summary>

  ```dart
  enum ExitCode {
    /// The successful exit.
    success(0),
  
    /// The command was used incorrectly.
    usage(64),
  
    /// An internal software error has been detected.
    software(70),
  
    /// Something was found in an unconfigured or misconfigured state.
    config(78);
  
    final int code;
  
    const ExitCode(this.code);
  }
  ```
</details>