### PR TITLE
fix: correctly handle empty comment sentence for format-comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * feat: add `allow-initialized` option to [`avoid-late-keyword`](https://dcm.dev/docs/individuals/rules/common/avoid-late-keyword).
 * feat: add `ignored-types` option to [`avoid-late-keyword`](https://dcm.dev/docs/individuals/rules/common/avoid-late-keyword).
 * fix: support tear-off methods for `check-unnecessary-nullable`.
+* fix: correctly handle empty comment sentence for [`format-comment`](https://dcm.dev/docs/individuals/rules/common/format-comment).
 
 ## 5.4.0
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
@@ -110,6 +110,9 @@ class _Visitor extends RecursiveAstVisitor<void> {
 
   bool _isValidSentence(String sentence) {
     final trimmedSentence = sentence.trim();
+    if (trimmedSentence.isEmpty) {
+      return true;
+    }
 
     final upperCase = trimmedSentence[0] == trimmedSentence[0].toUpperCase();
     final lastSymbol =


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

### What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New rule
- [ ] Changes an existing rule
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:
