### PR TITLE
fix: correctly support dartdoc tags for format-comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* fix: correctly support dartdoc tags for [`format-comment`](https://dcm.dev/docs/individuals/rules/common/format-comment).
+
 ## 5.6.0-dev.1
 
 * docs: remove old website

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/format_comment/visitor.dart
@@ -3,8 +3,7 @@ part of 'format_comment_rule.dart';
 const _punctuation = ['.', '!', '?', ':'];
 
 final _sentencesRegExp = RegExp(r'(?<=([\.|:](?=\s|\n|$)))');
-final _regMacrosExp = RegExp('{@(template|macro) .+}');
-const _macrosEndExp = '{@endtemplate}';
+final _regMacrosExp = RegExp('{@.+}');
 const _ignoreExp = 'ignore:';
 const _ignoreForFileExp = 'ignore_for_file:';
 
@@ -141,7 +140,6 @@ class _Visitor extends RecursiveAstVisitor<void> {
     final trimmed = text.trim();
 
     return _regMacrosExp.hasMatch(text) ||
-        text.contains(_macrosEndExp) ||
         _isIgnoreComment(trimmed) ||
         _isIgnoredPattern(trimmed);
   }
@@ -149,8 +147,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
   bool _isIgnoreComment(String text) =>
       text.startsWith(_ignoreExp) || text.startsWith(_ignoreForFileExp);
 
-  bool _isMacros(String text) =>
-      _regMacrosExp.hasMatch(text) || text == _macrosEndExp;
+  bool _isMacros(String text) => _regMacrosExp.hasMatch(text);
 
   bool _isIgnoredPattern(String text) =>
       _ignoredPatterns.any((regExp) => regExp.hasMatch(text));

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/format_comment/examples/example_documentation.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/format_comment/examples/example_documentation.dart
@@ -28,3 +28,6 @@ void f3() {}
 
 /// {@template my_project.my_class.my_method}
 void f4() {}
+
+/// {@nodoc}
+void f5() {}


### PR DESCRIPTION
# Please write a short comment explaining your change (or "none" for internal only changes)

Add dartdoc tags support for `format-comment`.
