### PR TITLE
feat: add new config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix: add new config option for [`no-equal-arguments`](https://dcm.dev/docs/individuals/rules/common/no-equal-arguments).
 * fix: support `assert(mounted)` for [`use-setstate-synchronously`](https://dcm.dev/docs/individuals/rules/flutter/use-setstate-synchronously).
 * fix: correctly support dartdoc tags for [`format-comment`](https://dcm.dev/docs/individuals/rules/common/format-comment).
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/config_parser.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/config_parser.dart
@@ -2,6 +2,13 @@ part of 'no_equal_arguments_rule.dart';
 
 class _ConfigParser {
   static const _ignoredParametersConfig = 'ignored-parameters';
+  static const _ignoredArgumentsConfig = 'ignored-arguments';
+
+  static Iterable<String> parseIgnoredArguments(Map<String, Object> config) =>
+      config.containsKey(_ignoredArgumentsConfig) &&
+              config[_ignoredArgumentsConfig] is Iterable
+          ? List<String>.from(config[_ignoredArgumentsConfig] as Iterable)
+          : <String>[];
 
   static Iterable<String> parseIgnoredParameters(Map<String, Object> config) =>
       config.containsKey(_ignoredParametersConfig) &&

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/no_equal_arguments_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/no_equal_arguments_rule.dart
@@ -2,6 +2,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:collection/collection.dart';
 
 import '../../../../../utils/node_utils.dart';
 import '../../../lint_utils.dart';
@@ -20,9 +21,11 @@ class NoEqualArgumentsRule extends CommonRule {
   static const _warningMessage = 'The argument has already been passed.';
 
   final Iterable<String> _ignoredParameters;
+  final Iterable<String> _ignoredArguments;
 
   NoEqualArgumentsRule([Map<String, Object> config = const {}])
       : _ignoredParameters = _ConfigParser.parseIgnoredParameters(config),
+        _ignoredArguments = _ConfigParser.parseIgnoredArguments(config),
         super(
           id: ruleId,
           severity: readSeverity(config, Severity.warning),
@@ -34,13 +37,14 @@ class NoEqualArgumentsRule extends CommonRule {
   Map<String, Object?> toJson() {
     final json = super.toJson();
     json[_ConfigParser._ignoredParametersConfig] = _ignoredParameters.toList();
+    json[_ConfigParser._ignoredArgumentsConfig] = _ignoredArguments.toList();
 
     return json;
   }
 
   @override
   Iterable<Issue> check(InternalResolvedUnitResult source) {
-    final visitor = _Visitor(_ignoredParameters);
+    final visitor = _Visitor(_ignoredParameters, _ignoredArguments);
 
     source.unit.visitChildren(visitor);
 

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/no_equal_arguments_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/no_equal_arguments_rule_test.dart
@@ -87,4 +87,33 @@ void main() {
 
     RuleTestHelper.verifyNoIssues(issues);
   });
+
+  test('reports about found issue with ignored arguments config', () async {
+    final unit = await RuleTestHelper.resolveFromFile(_incorrectExamplePath);
+    final issues = NoEqualArgumentsRule({
+      'ignored-arguments': ['firstName'],
+    }).check(unit);
+
+    RuleTestHelper.verifyIssues(
+      issues: issues,
+      startLines: [32, 37, 42, 47, 54, 59],
+      startColumns: [5, 5, 5, 5, 5, 5],
+      locationTexts: [
+        'user.firstName',
+        'user.getName',
+        'user.getFirstName()',
+        "user.getNewName('name')",
+        'user.getNewName(name)',
+        'lastName: user.firstName',
+      ],
+      messages: [
+        'The argument has already been passed.',
+        'The argument has already been passed.',
+        'The argument has already been passed.',
+        'The argument has already been passed.',
+        'The argument has already been passed.',
+        'The argument has already been passed.',
+      ],
+    );
+  });
 }


### PR DESCRIPTION
# Please write a short comment explaining your change (or "none" for internal only changes)

Adds new config option `ignored-arguments` to `no-equal-arguments` rule.
