### PR TITLE
fix: correctly handle dynamic type for avoid-passing-async-when-sync-expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix: correctly handle `dynamic` type for [`avoid-passing-async-when-sync-expected`](https://dcm.dev/docs/individuals/rules/common/avoid-passing-async-when-sync-expected).
 * feat: add `allow-nullable` config option for [`avoid-returning-widgets`](https://dcm.dev/docs/individuals/rules/common/avoid-returning-widgets).
 * fix: support `assert(mounted)` for [`use-setstate-synchronously`](https://dcm.dev/docs/individuals/rules/flutter/use-setstate-synchronously).
 * fix: correctly support dartdoc tags for [`format-comment`](https://dcm.dev/docs/individuals/rules/common/format-comment).

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected_rule.dart
@@ -36,10 +36,7 @@ class AvoidPassingAsyncWhenSyncExpectedRule extends CommonRule {
     return visitor.invalidArguments
         .map((invocation) => createIssue(
               rule: this,
-              location: nodeLocation(
-                node: invocation,
-                source: source,
-              ),
+              location: nodeLocation(node: invocation, source: source),
               message: _warningMessage,
             ))
         .toList(growable: false);

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/visitor.dart
@@ -29,11 +29,16 @@ class _Visitor extends RecursiveAstVisitor<void> {
       final parameterType = argument.staticParameterElement?.type;
       if (argumentType is FunctionType && parameterType is FunctionType) {
         if (argumentType.returnType.isDartAsyncFuture &&
-            (!parameterType.returnType.isDartAsyncFuture &&
-                !parameterType.returnType.isDartAsyncFutureOr)) {
+            !_hasValidFutureType(parameterType.returnType)) {
           _invalidArguments.add(argument);
         }
       }
     }
   }
+
+  bool _hasValidFutureType(DartType type) =>
+      type.isDartAsyncFuture ||
+      type.isDartAsyncFutureOr ||
+      type.isDynamic ||
+      type.isDartCoreObject;
 }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/avoid_passing_async_when_sync_expected_rule_test.dart
@@ -26,7 +26,7 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [49, 54, 57, 84],
+        startLines: [49, 54, 57, 87],
         startColumns: [7, 7, 7, 9],
         locationTexts: [
           'synchronousWork: work1',

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_passing_async_when_sync_expected/examples/example.dart
@@ -55,6 +55,7 @@ class _MyHomePageState extends State<MyHomePage> {
         print('work 3');
       },
       synchronousWork4: work4, // LINT
+      synchronousWork5: work1,
     );
   }
 
@@ -63,11 +64,13 @@ class _MyHomePageState extends State<MyHomePage> {
     required VoidCallback synchronousWork2,
     required VoidCallback synchronousWork3,
     required VoidCallback synchronousWork4,
+    required dynamic Function() synchronousWork5,
   }) {
     synchronousWork();
     synchronousWork2();
     synchronousWork3();
     synchronousWork4();
+    synchronousWork5();
   }
 
   void _incrementCounter() {


### PR DESCRIPTION
# Please write a short comment explaining your change (or "none" for internal only changes)

Properly handle `dynamic` type.
