### PR TITLE
fix: correctly handle implicit type parameters for no-equal-arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* fix: correctly handle implicit type parameters for [`no-equal-arguments`](https://dcm.dev/docs/individuals/rules/common/no-equal-arguments).
 * feat: add `allow-nullable` config option for [`avoid-returning-widgets`](https://dcm.dev/docs/individuals/rules/common/avoid-returning-widgets).
 * fix: support `assert(mounted)` for [`use-setstate-synchronously`](https://dcm.dev/docs/individuals/rules/flutter/use-setstate-synchronously).
 * fix: correctly support dartdoc tags for [`format-comment`](https://dcm.dev/docs/individuals/rules/common/format-comment).

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/visitor.dart
@@ -39,8 +39,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
             arg is NamedExpression &&
             argument.expression is! Literal &&
             arg.expression is! Literal) {
-          return argument.expression.staticParameterElement ==
-                  arg.expression.staticParameterElement &&
+          return argument.expression.staticParameterElement?.type ==
+                  arg.expression.staticParameterElement?.type &&
               argument.expression.toString() == arg.expression.toString();
         }
 
@@ -48,7 +48,8 @@ class _Visitor extends RecursiveAstVisitor<void> {
           return argument == arg;
         }
 
-        return argument.staticParameterElement == arg.staticParameterElement &&
+        return argument.staticParameterElement?.type ==
+                arg.staticParameterElement?.type &&
             argument.toString() == arg.toString();
       });
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/visitor.dart
@@ -40,8 +40,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
             arg is NamedExpression &&
             argument.expression is! Literal &&
             arg.expression is! Literal) {
-          return argument.expression.staticParameterElement?.type ==
-                  arg.expression.staticParameterElement?.type &&
+          return haveSameParameterType(argument.expression, arg.expression) &&
               argument.expression.toString() == arg.expression.toString();
         }
 
@@ -49,8 +48,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
           return argument == arg;
         }
 
-        return argument.staticParameterElement?.type ==
-                arg.staticParameterElement?.type &&
+        return haveSameParameterType(argument, arg) &&
             argument.toString() == arg.toString();
       });
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/visitor.dart
@@ -39,14 +39,17 @@ class _Visitor extends RecursiveAstVisitor<void> {
             arg is NamedExpression &&
             argument.expression is! Literal &&
             arg.expression is! Literal) {
-          return argument.expression.toString() == arg.expression.toString();
+          return argument.expression.staticParameterElement ==
+                  arg.expression.staticParameterElement &&
+              argument.expression.toString() == arg.expression.toString();
         }
 
         if (_bothLiterals(argument, arg)) {
           return argument == arg;
         }
 
-        return argument.toString() == arg.toString();
+        return argument.staticParameterElement == arg.staticParameterElement &&
+            argument.toString() == arg.toString();
       });
 
       if (argument != lastAppearance) {

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
@@ -201,6 +201,5 @@ class _BlockVisitor extends RecursiveAstVisitor<void> {
   bool _haveDifferentParameterTypes(AstNode visitedInvocation, AstNode node) =>
       visitedInvocation is Expression &&
       node is Expression &&
-      visitedInvocation.staticParameterElement?.type !=
-          node.staticParameterElement?.type;
+      !haveSameParameterType(visitedInvocation, node);
 }

--- a/lib/src/utils/node_utils.dart
+++ b/lib/src/utils/node_utils.dart
@@ -43,6 +43,9 @@ bool isOverride(List<Annotation> metadata) => metadata.any(
           node.name.name == 'override' && node.atSign.type == TokenType.AT,
     );
 
+bool haveSameParameterType(Expression left, Expression right) =>
+    left.staticParameterElement?.type == right.staticParameterElement?.type;
+
 bool isEntrypoint(String name, NodeList<Annotation> metadata) =>
     name == 'main' ||
     _hasPragmaAnnotation(metadata) ||

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/examples/provider_example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/examples/provider_example.dart
@@ -1,0 +1,55 @@
+class MyApp extends StatefulWidget {
+  const MyApp();
+}
+
+class _MyAppState extends State<MyApp> {
+  @override
+  void initState() {
+    super.initState();
+
+    final model = MyModel(
+      context.read(),
+      context.read(),
+      context.read(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+class A {}
+
+class B {}
+
+class C {}
+
+class MyModel {
+  final A a;
+  final B b;
+  final C c;
+
+  const MyModel(this.a, this.b, this.c);
+}
+
+class Widget {}
+
+class StatefulWidget extends Widget {}
+
+class BuildContext {}
+
+extension ReadContext on BuildContext {
+  T read<T>() {
+    return 'value' as T;
+  }
+}
+
+abstract class State<T> {
+  void initState();
+
+  void setState(VoidCallback callback) => callback();
+
+  BuildContext get context => BuildContext();
+}

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/no_equal_arguments_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/no_equal_arguments_rule_test.dart
@@ -60,40 +60,40 @@ void main() {
 
       RuleTestHelper.verifyNoIssues(issues);
     });
-  });
 
-  test('reports about found issue with default config', () async {
-    final unit =
-        await RuleTestHelper.resolveFromFile(_namedParametersExamplePath);
-    final issues = NoEqualArgumentsRule().check(unit);
+    test('reports about found issue with default config', () async {
+      final unit =
+          await RuleTestHelper.resolveFromFile(_namedParametersExamplePath);
+      final issues = NoEqualArgumentsRule().check(unit);
 
-    RuleTestHelper.verifyIssues(
-      issues: issues,
-      startLines: [9],
-      startColumns: [3],
-      locationTexts: ['lastName: firstName'],
-      messages: ['The argument has already been passed.'],
-    );
-  });
+      RuleTestHelper.verifyIssues(
+        issues: issues,
+        startLines: [9],
+        startColumns: [3],
+        locationTexts: ['lastName: firstName'],
+        messages: ['The argument has already been passed.'],
+      );
+    });
 
-  test('reports no issues for provider read', () async {
-    final unit = await RuleTestHelper.resolveFromFile(_providerExamplePath);
-    final issues = NoEqualArgumentsRule().check(unit);
+    test('reports no issues for provider read', () async {
+      final unit = await RuleTestHelper.resolveFromFile(_providerExamplePath);
+      final issues = NoEqualArgumentsRule().check(unit);
 
-    RuleTestHelper.verifyNoIssues(issues);
-  });
+      RuleTestHelper.verifyNoIssues(issues);
+    });
 
-  test('reports no issues with custom config', () async {
-    final unit =
-        await RuleTestHelper.resolveFromFile(_namedParametersExamplePath);
-    final config = {
-      'ignored-parameters': [
-        'lastName',
-      ],
-    };
+    test('reports no issues with custom config', () async {
+      final unit =
+          await RuleTestHelper.resolveFromFile(_namedParametersExamplePath);
+      final config = {
+        'ignored-parameters': [
+          'lastName',
+        ],
+      };
 
-    final issues = NoEqualArgumentsRule(config).check(unit);
+      final issues = NoEqualArgumentsRule(config).check(unit);
 
-    RuleTestHelper.verifyNoIssues(issues);
+      RuleTestHelper.verifyNoIssues(issues);
+    });
   });
 }

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/no_equal_arguments_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/no_equal_arguments/no_equal_arguments_rule_test.dart
@@ -9,6 +9,8 @@ const _incorrectExamplePath =
     'no_equal_arguments/examples/incorrect_example.dart';
 const _namedParametersExamplePath =
     'no_equal_arguments/examples/named_parameters_example.dart';
+const _providerExamplePath =
+    'no_equal_arguments/examples/provider_example.dart';
 
 void main() {
   group('NoEqualArgumentsRule', () {
@@ -72,6 +74,13 @@ void main() {
       locationTexts: ['lastName: firstName'],
       messages: ['The argument has already been passed.'],
     );
+  });
+
+  test('reports no issues for provider read', () async {
+    final unit = await RuleTestHelper.resolveFromFile(_providerExamplePath);
+    final issues = NoEqualArgumentsRule().check(unit);
+
+    RuleTestHelper.verifyNoIssues(issues);
   });
 
   test('reports no issues with custom config', () async {


### PR DESCRIPTION
# Please write a short comment explaining your change (or "none" for internal only changes)

Fix implicit type parameters for `no-equal-arguments`.
