### PR TITLE
fix: handle dynamics in map literals for avoid-dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * fix: handle dynamics in map literals for [`avoid-dynamic`](https://dcm.dev/docs/individuals/rules/common/avoid-dynamic).
+* fix: change anti-patterns default severity to `warning`.
 
 ## 5.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* fix: handle dynamics in map literals for [`avoid-dynamic`](https://dcm.dev/docs/individuals/rules/common/avoid-dynamic).
+
 ## 5.6.0
 
 * fix: correctly handle implicit type parameters for [`no-equal-arguments`](https://dcm.dev/docs/individuals/rules/common/no-equal-arguments).

--- a/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_method.dart
+++ b/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_method.dart
@@ -34,7 +34,7 @@ class LongMethod extends Pattern {
         ),
         super(
           id: patternId,
-          severity: readSeverity(patternSettings, Severity.none),
+          severity: readSeverity(patternSettings, Severity.warning),
           excludes: readExcludes(patternSettings),
         );
 

--- a/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_parameter_list.dart
+++ b/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_parameter_list.dart
@@ -32,7 +32,7 @@ class LongParameterList extends Pattern {
         ),
         super(
           id: patternId,
-          severity: readSeverity(patternSettings, Severity.none),
+          severity: readSeverity(patternSettings, Severity.warning),
           excludes: readExcludes(patternSettings),
         );
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_dynamic/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_dynamic/visitor.dart
@@ -10,13 +10,17 @@ class _Visitor extends RecursiveAstVisitor<void> {
     final parent = node.parent;
     if (parent is NamedType && (parent.type?.isDynamic ?? false)) {
       final grandParent = node.parent?.parent;
-      if (grandParent != null) {
-        final grandGrandParent = grandParent.parent;
-        if (!(grandGrandParent is NamedType &&
-            (grandGrandParent.type?.isDartCoreMap ?? false))) {
-          _nodes.add(grandParent);
-        }
+      if (grandParent != null && !_isWithinMap(grandParent)) {
+        _nodes.add(grandParent);
       }
     }
+  }
+
+  bool _isWithinMap(AstNode grandParent) {
+    final grandGrandParent = grandParent.parent;
+
+    return grandGrandParent is NamedType &&
+            (grandGrandParent.type?.isDartCoreMap ?? false) ||
+        grandGrandParent is SetOrMapLiteral && grandGrandParent.isMap;
   }
 }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_ignoring_return_values/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/avoid_ignoring_return_values/visitor.dart
@@ -38,6 +38,7 @@ class _Visitor extends RecursiveAstVisitor<void> {
       !_isEmptyFutureOrType(type);
 
   bool _isEmptyType(DartType type) =>
+      // ignore: deprecated_member_use
       type.isBottom || type.isDartCoreNull || type.isVoid;
 
   bool _isEmptyFutureType(DartType type) =>

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/check_for_equals_in_render_object_setters/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/check_for_equals_in_render_object_setters/visitor.dart
@@ -97,6 +97,7 @@ class _ReturnVisitor extends RecursiveAstVisitor<void> {
 
     final type = node.expression?.staticType;
 
+    // ignore: deprecated_member_use
     if (type == null || type.isVoid) {
       _hasValidReturn = true;
     }

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/prefer_moving_to_variable/visitor.dart
@@ -62,6 +62,7 @@ class _BlockVisitor extends RecursiveAstVisitor<void> {
   void visitMethodInvocation(MethodInvocation node) {
     if (node.parent is CascadeExpression ||
         node.parent is VariableDeclaration ||
+        // ignore: deprecated_member_use
         (node.staticType?.isVoid ?? false)) {
       return;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ platforms:
   macos:
 
 dependencies:
-  analyzer: ">=5.1.0 <5.8.0"
+  analyzer: ">=5.1.0 <5.9.0"
   analyzer_plugin: ">=0.11.0 <0.12.0"
   ansicolor: ^2.0.1
   args: ^2.0.0

--- a/test/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_method/long_method_test.dart
+++ b/test/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_method/long_method_test.dart
@@ -55,7 +55,7 @@ void main() {
       AntiPatternTestHelper.verifyInitialization(
         issues: issues,
         antiPatternId: 'long-method',
-        severity: Severity.none,
+        severity: Severity.warning,
       );
 
       AntiPatternTestHelper.verifyIssues(

--- a/test/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_parameter_list/long_parameter_list_test.dart
+++ b/test/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_parameter_list/long_parameter_list_test.dart
@@ -53,7 +53,7 @@ void main() {
     AntiPatternTestHelper.verifyInitialization(
       issues: issues,
       antiPatternId: 'long-parameter-list',
-      severity: Severity.none,
+      severity: Severity.warning,
     );
 
     AntiPatternTestHelper.verifyIssues(

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_dynamic/avoid_dynamic_rule_test.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_dynamic/avoid_dynamic_rule_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       RuleTestHelper.verifyIssues(
         issues: issues,
-        startLines: [2, 6, 10, 10, 10, 12, 23, 28, 31, 38],
+        startLines: [2, 6, 10, 10, 10, 12, 23, 28, 31, 39],
         startColumns: [3, 4, 1, 22, 33, 7, 3, 3, 3, 32],
         locationTexts: [
           'dynamic s = 1',

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_dynamic/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/avoid_dynamic/examples/example.dart
@@ -35,4 +35,9 @@ class SomeClass {
 
 abstract class BaseClass<T> {}
 
-class Generic extends BaseClass<dynamic> {} // LINT
+// LINT
+class Generic extends BaseClass<dynamic> {
+  final Map<String, dynamic> myMap = {};
+
+  final myMap = <String, dynamic>{};
+}


### PR DESCRIPTION
# Please write a short comment explaining your change (or "none" for internal only changes)

#1191 
