### PR TITLE
fix: change anti-patterns default severity to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * fix: handle dynamics in map literals for [`avoid-dynamic`](https://dcm.dev/docs/individuals/rules/common/avoid-dynamic).
+* fix: change anti-patterns default severity to `warning`.
 
 ## 5.6.0
 

--- a/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_method.dart
+++ b/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_method.dart
@@ -34,7 +34,7 @@ class LongMethod extends Pattern {
         ),
         super(
           id: patternId,
-          severity: readSeverity(patternSettings, Severity.none),
+          severity: readSeverity(patternSettings, Severity.warning),
           excludes: readExcludes(patternSettings),
         );
 

--- a/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_parameter_list.dart
+++ b/lib/src/analyzers/lint_analyzer/anti_patterns/anti_patterns_list/long_parameter_list.dart
@@ -32,7 +32,7 @@ class LongParameterList extends Pattern {
         ),
         super(
           id: patternId,
-          severity: readSeverity(patternSettings, Severity.none),
+          severity: readSeverity(patternSettings, Severity.warning),
           excludes: readExcludes(patternSettings),
         );
 


### PR DESCRIPTION
# Please write a short comment explaining your change (or "none" for internal only changes)

#1193 
