### PR TITLE
fix: visit only widgets for use-setstate-synchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * chore: restrict `analyzer` version to `>=5.1.0 <5.8.0`.
 * feat: add static code diagnostic [`avoid-substring`](https://dcm.dev/docs/individuals/rules/common/avoid-substring).
 * fix: correctly track prefixes usage for check-unused-code.
+* fix: visit only widgets for [`use-setstate-synchronously`](https://dcm.dev/docs/individuals/rules/flutter/use-setstate-synchronously).
 
 ## 5.6.0
 

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/use_setstate_synchronously_rule.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/use_setstate_synchronously_rule.dart
@@ -33,7 +33,7 @@ class UseSetStateSynchronouslyRule extends FlutterRule {
   @override
   Iterable<Issue> check(InternalResolvedUnitResult source) {
     final visitor = _Visitor(methods: methods);
-    source.unit.visitChildren(visitor);
+    source.unit.accept(visitor);
 
     return visitor.nodes
         .map((node) => createIssue(

--- a/lib/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/visitor.dart
+++ b/lib/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/visitor.dart
@@ -8,9 +8,14 @@ class _Visitor extends RecursiveAstVisitor<void> {
   final nodes = <SimpleIdentifier>[];
 
   @override
-  void visitClassDeclaration(ClassDeclaration node) {
-    if (isWidgetStateOrSubclass(node.extendsClause?.superclass.type)) {
-      node.visitChildren(this);
+  void visitCompilationUnit(CompilationUnit node) {
+    for (final declaration in node.declarations) {
+      if (declaration is ClassDeclaration) {
+        final type = declaration.extendsClause?.superclass.type;
+        if (isWidgetStateOrSubclass(type)) {
+          declaration.visitChildren(this);
+        }
+      }
     }
   }
 

--- a/test/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/examples/example.dart
+++ b/test/src/analyzers/lint_analyzer/rules/rules_list/use_setstate_synchronously/examples/example.dart
@@ -109,3 +109,35 @@ class State {}
 Future<void> fetch() {}
 
 Future<bool> condition() {}
+
+class SomeClass {
+  void setState(Function() callback) {}
+}
+
+Future<void> handle(Future Function() callback) {}
+
+mixin _SomeMixin on SomeClass {
+  Future<bool> condition() => handle(() async {
+        await fetch();
+
+        setState();
+      });
+}
+
+abstract class IController {
+  void setState(void Function() fn);
+}
+
+abstract class ControllerBase implements IController {
+  @override
+  void setState(void Function() fn) {}
+}
+
+class ControllerImpl = ControllerBase with ControllerMixin;
+
+mixin ControllerMixin on ControllerBase {
+  Future<void> helloWorld() async {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    setState(() {});
+  }
+}


### PR DESCRIPTION
# Please write a short comment explaining your change (or "none" for internal only changes)

Fix false-positives for `use-setstate-synchronously`.
