### PR TITLE
docs: fix prefer-define-hero-tag changelog link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * fix: handle dynamics in map literals for [`avoid-dynamic`](https://dcm.dev/docs/individuals/rules/common/avoid-dynamic).
 * fix: change anti-patterns default severity to `warning`.
-* feat: add static code diagnostic [`prefer-define-hero-tag`](https://dcm.dev/docs/individuals/rules/common/prefer-define-hero-tag).
+* feat: add static code diagnostic [`prefer-define-hero-tag`](https://dcm.dev/docs/individuals/rules/flutter/prefer-define-hero-tag).
 * chore: restrict `analyzer` version to `>=5.1.0 <5.9.0`.
 * feat: add static code diagnostic [`avoid-substring`](https://dcm.dev/docs/individuals/rules/common/avoid-substring).
 * fix: correctly track prefixes usage for check-unused-code.


### PR DESCRIPTION

Noticed a 404 from https://pub.dev/packages/dart_code_metrics/changelog 
It's a flutter rule sooo fixing

